### PR TITLE
Throw error when no APY data ready

### DIFF
--- a/src/api/stats/index.js
+++ b/src/api/stats/index.js
@@ -9,11 +9,14 @@ async function apy(ctx) {
     ctx.request.socket.setTimeout(TIMEOUT);
     let apys = await getApys();
 
+    if (Object.keys(apys).length === 0) {
+      throw 'There is no APYs data yet'
+    }
+
     ctx.status = 200;
     ctx.body = apys;
   } catch (err) {
-    console.error(err);
-    ctx.status = 500;
+    ctx.throw(500, err);
   }
 }
 


### PR DESCRIPTION
Make context to throw an error when data is not ready yet. Having an errored response code will prevent caching of an empty APYs object until it's ready.