### PR TITLE
Feature: fetch pancake contract prices

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,3 +1,6 @@
+const BSC_CHAIN_ID = 56;
+const HECO_CHAIN_ID = 128;
+
 const MAINNET_BSC_RPC_ENDPOINTS = [
   'https://bsc-dataseed.binance.org',
   'https://bsc-dataseed1.defibit.io',
@@ -31,7 +34,9 @@ const FORTUBE_API_TOKEN = process.env.FORTUBE_API_TOKEN;
 module.exports = {
   BSC_RPC,
   BSC_RPC_ENDPOINTS,
+  BSC_CHAIN_ID,
   HECO_RPC,
+  HECO_CHAIN_ID,
   REWARDER_PRIVATE_KEY,
   BASE_HPY,
   HOURLY_HPY,

--- a/src/api/price/index.js
+++ b/src/api/price/index.js
@@ -1,6 +1,7 @@
 const { lpTokenPrices } = require('../../utils/lpTokens');
 const fetchPrice = require('../../utils/fetchPrice');
 const { getNyanswopTokenPrices } = require('../stats/nyanswop/getNyanswopPrice');
+const { getCakeTokensPrices } = require('../stats/pancake/getCakePrices');
 const cakeLpTokens = require('../../data/cakeLpPools.json');
 const thugsLpTokens = require('../../data/thugsLpPools.json');
 const bakeryLpTokens = require('../../data/bakeryLpPools.json');
@@ -25,8 +26,7 @@ async function lpPrices(ctx, lpTokens) {
     ctx.status = 200;
     ctx.body = prices;
   } catch (err) {
-    console.error(err);
-    ctx.status = 500;
+    ctx.throw(500, err);
   }
 }
 
@@ -93,8 +93,7 @@ async function bakeryPrices(ctx) {
     ctx.status = 200;
     ctx.body = { BETH: price };
   } catch (err) {
-    console.error(err);
-    ctx.status = 500;
+    ctx.throw(500, err);
   }
 }
 
@@ -104,8 +103,17 @@ async function nyanswopPrices(ctx) {
     ctx.status = 200;
     ctx.body = prices;
   } catch (err) {
-    console.error(err);
-    ctx.status = 500;
+    ctx.throw(500, err);
+  }
+}
+
+async function pancakePrices(ctx) {
+  try {
+    const prices = await getCakeTokensPrices();
+    ctx.status = 200;
+    ctx.body = prices;
+  } catch (err) {
+    ctx.throw(500, err);
   }
 }
 
@@ -123,6 +131,7 @@ module.exports = {
   kebabLpPrices,
   monsterLpPrices,
   nyanswopLpPrices,
+  pancakePrices,
   spongeLpPrices,
   boltLpPrices,
   autoLpPrices,

--- a/src/api/proxy.js
+++ b/src/api/proxy.js
@@ -2,17 +2,6 @@
 
 const axios = require('axios');
 
-async function pancake(ctx) {
-  try {
-    const rsp = await axios.get('https://api.pancakeswap.finance/api/v1/price');
-    ctx.body = rsp.data;
-    ctx.status = rsp.status;
-  } catch (err) {
-    console.error(err);
-    ctx.status = 500;
-  }
-}
-
 async function thugs(ctx) {
   try {
     const rsp = await axios.get('https://api.streetswap.vip/tickers');
@@ -24,4 +13,4 @@ async function thugs(ctx) {
   }
 }
 
-module.exports = { pancake, thugs };
+module.exports = { thugs };

--- a/src/api/stats/pancake/getCakePrices.js
+++ b/src/api/stats/pancake/getCakePrices.js
@@ -8,7 +8,7 @@ let knownPrices = {
   BUSD: 1
 }
 
-const refreshInterval = 2 * 60 * 1000;
+const refreshInterval = 10 * 60 * 1000;
 let priceCache = {};
 let isProcessing = false;
 

--- a/src/api/stats/pancake/getCakePrices.js
+++ b/src/api/stats/pancake/getCakePrices.js
@@ -4,7 +4,7 @@ const { fetchPoolTokensPrices } = require('../../../utils/getPoolStats')
 const pools = require('../../../data/cakeLpPools.json');
 const oracle = 'pancake';
 
-let knownPrices = {
+const knownPrices = {
   BUSD: 1
 }
 

--- a/src/api/stats/pancake/getCakePrices.js
+++ b/src/api/stats/pancake/getCakePrices.js
@@ -1,0 +1,48 @@
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const { fetchPoolTokensPrices } = require('../../../utils/getPoolStats')
+
+const pools = require('../../../data/cakeLpPools.json');
+const oracle = 'pancake';
+
+let knownPrices = {
+  BUSD: 1
+}
+
+const refreshInterval = 2 * 60 * 1000;
+let priceCache = {};
+let isProcessing = false;
+
+const fetchCakeTokensPrices = async () => {
+  isProcessing = true;
+  try {
+    priceCache = await fetchPoolTokensPrices(
+      oracle,
+      pools,
+      knownPrices,
+      BSC_CHAIN_ID
+    )
+  } catch (err) {
+    console.error(err)
+  }
+  isProcessing = false;
+}
+fetchCakeTokensPrices();
+
+const fetchInterval = setInterval(() => {
+  if (!isProcessing) {
+    fetchCakeTokensPrices();
+  }
+}, refreshInterval);
+
+const getCakeTokensPrices = async () => {
+  while (isProcessing) {
+     await sleep(500);
+  }
+  return priceCache;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = { getCakeTokensPrices };

--- a/src/data/cakeLpPools.json
+++ b/src/data/cakeLpPools.json
@@ -828,42 +828,6 @@
     }
   },
   {
-    "name": "cake-cake-bnb",
-    "address": "0xA527a61703D82139F8a06Bc30097cC9CAA2df5A6",
-    "decimals": "1e18",
-    "poolId": 1,
-    "lp0": {
-      "address": "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82",
-      "oracle": "pancake",
-      "oracleId": "Cake",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
-      "oracle": "pancake",
-      "oracleId": "WBNB",
-      "decimals": "1e18"
-    }
-  },
-  {
-    "name": "cake-busd-bnb",
-    "address": "0x1B96B92314C44b159149f7E0303511fB2Fc4774f",
-    "decimals": "1e18",
-    "poolId": 2,
-    "lp0": {
-      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
-      "oracle": "pancake",
-      "oracleId": "WBNB",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
-      "oracle": "pancake",
-      "oracleId": "BUSD",
-      "decimals": "1e18"
-    }
-  },
-  {
     "name": "cake-usdt-busd",
     "address": "0xc15fa3E22c912A276550F3E5FE3b0Deb87B55aCd",
     "decimals": "1e18",
@@ -950,6 +914,42 @@
       "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
       "oracle": "pancake",
       "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-cake-bnb",
+    "address": "0xA527a61703D82139F8a06Bc30097cC9CAA2df5A6",
+    "decimals": "1e18",
+    "poolId": 1,
+    "lp0": {
+      "address": "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82",
+      "oracle": "pancake",
+      "oracleId": "Cake",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-busd-bnb",
+    "address": "0x1B96B92314C44b159149f7E0303511fB2Fc4774f",
+    "decimals": "1e18",
+    "poolId": 2,
+    "lp0": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+      "oracle": "pancake",
+      "oracleId": "BUSD",
       "decimals": "1e18"
     }
   }

--- a/src/router.js
+++ b/src/router.js
@@ -23,7 +23,7 @@ router.get('/supply/circulating', supply.circulating);
 router.get('/earnings', gov.earnings);
 router.get('/holders', gov.holderCount);
 
-router.get('/pancake/price', proxy.pancake);
+router.get('/pancake/price', price.pancakePrices);
 router.get('/thugs/tickers', proxy.thugs);
 router.get('/bakery/price', price.bakeryPrices);
 router.get('/nyanswop/price', price.nyanswopPrices);

--- a/src/utils/fetchPrice.js
+++ b/src/utils/fetchPrice.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const { lpTokenRatio } = require('./lpTokensRatio');
 const { getNyanswopTokenPrice } = require('../api/stats/nyanswop/getNyanswopPrice');
+const { getCakeTokensPrices } = require('../api/stats/pancake/getCakePrices');
 
 const endpoints = {
   bakery: 'https://api.beefy.finance/bakery/price',
@@ -9,7 +10,6 @@ const endpoints = {
   coingecko: 'https://api.coingecko.com/api/v3/simple/price',
   jetfuelLp: 'https://api.beefy.finance/jetfuel/lps',
   narwhalLp: 'https://api.beefy.finance/narwhal/lps',
-  pancake: 'https://api.beefy.finance/pancake/price',
   pancakeLp: 'https://api.beefy.finance/pancake/lps',
   thugsLp: 'https://api.beefy.finance/thugs/lps',
   thugs: 'https://api.beefy.finance/thugs/tickers',
@@ -49,14 +49,9 @@ const fetchCoingecko = async id => {
   }
 };
 
-const fetchPancake = async id => {
-  try {
-    const response = await axios.get(endpoints.pancake);
-    return response.data.prices[id];
-  } catch (err) {
-    console.error(err);
-    return 0;
-  }
+const fetchPancake = async (id, oracle) => {
+  const cakePrices = await getCakeTokensPrices();
+  return cakePrices[id] || 0;
 };
 
 const fetchThugs = async id => {

--- a/src/utils/getPoolStats.js
+++ b/src/utils/getPoolStats.js
@@ -1,0 +1,85 @@
+const BigNumber = require('bignumber.js');
+const { web3Factory } = require('./web3');
+const { BSC_CHAIN_ID } = require('../../constants');
+const ERC20 = require('../abis/ERC20.json');
+
+const fetchPoolTokenBalance = async (
+  lpAddress,
+  tokenAddress,
+  chainId = BSC_CHAIN_ID
+) => {
+  const web3 = web3Factory(chainId);
+
+  const tokenContract = new web3.eth.Contract(ERC20, tokenAddress);
+  const tokenBalance = new BigNumber(
+    await tokenContract.methods.balanceOf(lpAddress).call()
+  );
+
+  return tokenBalance;
+}
+
+const fetchPoolUnknownTokenPrice = async (
+  lpAddress,
+  unknownTokenAddress,
+  knownTokenAddress,
+  knownTokenPricePerUnit,
+  chainId = BSC_CHAIN_ID
+) => {
+  const knownTokenBalance = await fetchPoolTokenBalance(lpAddress, knownTokenAddress, chainId)
+  const knownTokenTotalValue = knownTokenBalance.times(knownTokenPricePerUnit);
+
+  const unknownTokenBalance = await fetchPoolTokenBalance(lpAddress, unknownTokenAddress, chainId)
+  const unknownTokenPriceUnit = knownTokenTotalValue.dividedBy(unknownTokenBalance);
+
+  return unknownTokenPriceUnit.toNumber();
+};
+
+const fetchPoolTokensPrices = async (
+  oracle,
+  pools,
+  knownPrices = {},
+  chainId = BSC_CHAIN_ID
+) => {
+  let knownToken, unknownToken, unknownTokenPrice;
+  for (const pool of [...pools].reverse()) {
+    if (pool.lp0.oracle != oracle || pool.lp0.oracle != oracle) {
+      continue;
+    }
+
+    if (knownPrices.hasOwnProperty(pool.lp0.oracleId) && knownPrices.hasOwnProperty(pool.lp1.oracleId)) {
+      continue;
+    }
+
+    if (knownPrices.hasOwnProperty(pool.lp0.oracleId) || knownPrices.hasOwnProperty(pool.lp1.oracleId)) {
+      if (knownPrices.hasOwnProperty(pool.lp0.oracleId)) {
+        knownToken = pool.lp0;
+        unknownToken = pool.lp1;
+      } else {
+        knownToken = pool.lp1;
+        unknownToken = pool.lp0;
+      }
+    } else {
+      console.warn('No path to resolve price of tokens in LP:', pool.name, 'Skipping it.')
+      console.warn('Please move leading pairs to the bottom of .json pools file')
+      continue;
+    }
+
+    unknownTokenPrice = await fetchPoolUnknownTokenPrice(
+      pool.address,
+      unknownToken.address,
+      knownToken.address,
+      knownPrices[knownToken.oracleId],
+      chainId
+    )
+
+    knownPrices[unknownToken.oracleId] = unknownTokenPrice;
+  }
+
+  return knownPrices;
+};
+
+module.exports = {
+  fetchPoolUnknownTokenPrice,
+  fetchPoolTokenBalance,
+  fetchPoolTokensPrices
+};

--- a/src/utils/getPoolStats.js
+++ b/src/utils/getPoolStats.js
@@ -37,21 +37,22 @@ const fetchPoolUnknownTokenPrice = async (
 const fetchPoolTokensPrices = async (
   oracle,
   pools,
-  knownPrices = {},
+  knownPrices,
   chainId = BSC_CHAIN_ID
 ) => {
+  let prices = {...knownPrices};
   let knownToken, unknownToken, unknownTokenPrice;
   for (const pool of [...pools].reverse()) {
     if (pool.lp0.oracle != oracle || pool.lp0.oracle != oracle) {
       continue;
     }
 
-    if (knownPrices.hasOwnProperty(pool.lp0.oracleId) && knownPrices.hasOwnProperty(pool.lp1.oracleId)) {
+    if (prices.hasOwnProperty(pool.lp0.oracleId) && prices.hasOwnProperty(pool.lp1.oracleId)) {
       continue;
     }
 
-    if (knownPrices.hasOwnProperty(pool.lp0.oracleId) || knownPrices.hasOwnProperty(pool.lp1.oracleId)) {
-      if (knownPrices.hasOwnProperty(pool.lp0.oracleId)) {
+    if (prices.hasOwnProperty(pool.lp0.oracleId) || prices.hasOwnProperty(pool.lp1.oracleId)) {
+      if (prices.hasOwnProperty(pool.lp0.oracleId)) {
         knownToken = pool.lp0;
         unknownToken = pool.lp1;
       } else {
@@ -68,14 +69,14 @@ const fetchPoolTokensPrices = async (
       pool.address,
       unknownToken,
       knownToken,
-      knownPrices[knownToken.oracleId],
+      prices[knownToken.oracleId],
       chainId
     )
 
-    knownPrices[unknownToken.oracleId] = unknownTokenPrice;
+    prices[unknownToken.oracleId] = unknownTokenPrice;
   }
 
-  return knownPrices;
+  return prices;
 };
 
 module.exports = {

--- a/src/utils/getPoolStats.js
+++ b/src/utils/getPoolStats.js
@@ -20,18 +20,18 @@ const fetchPoolTokenBalance = async (
 
 const fetchPoolUnknownTokenPrice = async (
   lpAddress,
-  unknownTokenAddress,
-  knownTokenAddress,
+  unknownToken,
+  knownToken,
   knownTokenPricePerUnit,
   chainId = BSC_CHAIN_ID
 ) => {
-  const knownTokenBalance = await fetchPoolTokenBalance(lpAddress, knownTokenAddress, chainId)
+  const knownTokenBalance = await fetchPoolTokenBalance(lpAddress, knownToken.address, chainId)
   const knownTokenTotalValue = knownTokenBalance.times(knownTokenPricePerUnit);
 
-  const unknownTokenBalance = await fetchPoolTokenBalance(lpAddress, unknownTokenAddress, chainId)
+  const unknownTokenBalance = await fetchPoolTokenBalance(lpAddress, unknownToken.address, chainId)
   const unknownTokenPriceUnit = knownTokenTotalValue.dividedBy(unknownTokenBalance);
 
-  return unknownTokenPriceUnit.toNumber();
+  return (unknownTokenPriceUnit.toNumber() / Number(knownToken.decimals)) * Number(unknownToken.decimals);
 };
 
 const fetchPoolTokensPrices = async (
@@ -66,8 +66,8 @@ const fetchPoolTokensPrices = async (
 
     unknownTokenPrice = await fetchPoolUnknownTokenPrice(
       pool.address,
-      unknownToken.address,
-      knownToken.address,
+      unknownToken,
+      knownToken,
       knownPrices[knownToken.oracleId],
       chainId
     )

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -1,5 +1,5 @@
 const Web3 = require('web3');
-const { BSC_RPC_ENDPOINTS, HECO_RPC } = require('../../constants');
+const { BSC_RPC_ENDPOINTS, HECO_RPC, BSC_CHAIN_ID, HECO_CHAIN_ID } = require('../../constants');
 
 const clients = { bsc: [], heco: [] };
 BSC_RPC_ENDPOINTS.forEach(endpoint => {
@@ -22,9 +22,9 @@ module.exports = {
 
   web3Factory: chainId => {
     switch (chainId) {
-      case 56:
+      case BSC_CHAIN_ID:
         return bscRandomClient();
-      case 128:
+      case HECO_CHAIN_ID:
         return hecoRandomClient();
     }
   },


### PR DESCRIPTION
Fixes #36, solution is 90% reusable for any AMM cross-chain. Once approved I will refactor #37 to pull data from contracts and `getNyanswopPrice.js` to prevent redundant RPC calls.

Leading pairs in `cakeLpPools.json` have been reorganised to respect price exploration order: BUSD -> WBNB -> CAKE -> other coins.

- [x] Repetitive calls handler for Pancake prices (could be propagated to every AMM to reduce RPC calls)
- [x] Constants for chain IDs
- [x] Proper context errors

