### PR TITLE
Feat: add bifi and other pancake token prices

### DIFF
--- a/src/api/price/index.js
+++ b/src/api/price/index.js
@@ -109,16 +109,15 @@ async function nyanswopPrices(ctx) {
   }
 }
 
-// FIXME: restoring partial service
-// async function pancakePrices(ctx) {
-//   try {
-//     const prices = await getCakeTokensPrices();
-//     ctx.status = 200;
-//     ctx.body = prices;
-//   } catch (err) {
-//     ctx.throw(500, err);
-//   }
-// }
+async function pancakePrices(ctx) {
+  try {
+    const prices = await getCakeTokensPrices();
+    ctx.status = 200;
+    ctx.body = prices;
+  } catch (err) {
+    ctx.throw(500, err);
+  }
+}
 
 module.exports = {
   cakeLpPrices,
@@ -133,7 +132,7 @@ module.exports = {
   kebabLpPrices,
   monsterLpPrices,
   nyanswopLpPrices,
-  // pancakePrices,
+  pancakePrices,
   spongeLpPrices,
   boltLpPrices,
   autoLpPrices,

--- a/src/api/stats/pancake/getCakePrices.js
+++ b/src/api/stats/pancake/getCakePrices.js
@@ -1,7 +1,8 @@
 const { BSC_CHAIN_ID } = require('../../../../constants');
 const { fetchPoolTokensPrices } = require('../../../utils/getPoolStats')
 
-const pools = require('../../../data/cakeLpPools.json');
+const lpPools = require('../../../data/cakeLpPools.json');
+const pools = require('../../../data/cakePools.json');
 const oracle = 'pancake';
 
 const knownPrices = {
@@ -17,7 +18,7 @@ const fetchCakeTokensPrices = async () => {
   try {
     priceCache = await fetchPoolTokensPrices(
       oracle,
-      pools,
+      [...lpPools, ...pools],
       knownPrices,
       BSC_CHAIN_ID
     )

--- a/src/data/cakeLpPools.json
+++ b/src/data/cakeLpPools.json
@@ -240,7 +240,7 @@
     "poolId": 62,
     "lp0": {
       "address": "0x3947B992DC0147D2D89dF0392213781b04B25075",
-      "oracle": "mirror",
+      "oracle": "pancake",
       "oracleId": "mAMZN",
       "decimals": "1e18"
     },
@@ -258,7 +258,7 @@
     "poolId": 61,
     "lp0": {
       "address": "0x62D71B23bF15218C7d2D7E48DBbD9e9c650B173f",
-      "oracle": "mirror",
+      "oracle": "pancake",
       "oracleId": "mGOOGL",
       "decimals": "1e18"
     },
@@ -276,7 +276,7 @@
     "poolId": 60,
     "lp0": {
       "address": "0xa04F060077D90Fe2647B61e4dA4aD1F97d6649dc",
-      "oracle": "mirror",
+      "oracle": "pancake",
       "oracleId": "mNFLX",
       "decimals": "1e18"
     },
@@ -294,7 +294,7 @@
     "poolId": 59,
     "lp0": {
       "address": "0xF215A127A196e3988C09d052e16BcFD365Cd7AA3",
-      "oracle": "mirror",
+      "oracle": "pancake",
       "oracleId": "mTSLA",
       "decimals": "1e18"
     },

--- a/src/data/cakePools.json
+++ b/src/data/cakePools.json
@@ -1,1 +1,223 @@
-[]
+[
+  {
+    "name": "cake-fuel-wbnb",
+    "address": "0x3763a3263ceaca5e7cc1bc22a43920bad9f743cd",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x2090c8295769791ab7a3cf1cc6e0aa19f35e441a",
+      "oracle": "pancake",
+      "oracleId": "Fuel",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-bake-wbnb",
+    "address": "0x3da30727ed0626b78c212e81b37b97a8ef8a25bb",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0xe02df9e3e622debdd69fb838bb799e3f168902c5",
+      "oracle": "pancake",
+      "oracleId": "BAKE",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-xrp-wbnb",
+    "address": "0xc7b4b32a3be2cb6572a1c9959401f832ce47a6d2",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x1d2f0da169ceb9fc7b3144628db156f3f6c60dbe",
+      "oracle": "pancake",
+      "oracleId": "XRP",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-fil-wbnb",
+    "address": "0x35fe9787f0ebf2a200bac413d3030cf62d312774",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x0d8ce2a99bb6e3b7db580ed848240e4a0f9ae153",
+      "oracle": "pancake",
+      "oracleId": "FIL",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-usdc-busd",
+    "address": "0x680dd100e4b394bda26a59dd5c119a391e747d18",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+      "oracle": "pancake",
+      "oracleId": "USDC",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+      "oracle": "pancake",
+      "oracleId": "BUSD",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-sxp-wbnb",
+    "address": "0x752e713fb70e3fa1ac08bcf34485f14a986956c4",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x47bead2563dcbf3bf2c9407fea4dc236faba485a",
+      "oracle": "pancake",
+      "oracleId": "SXP",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-bch-wbnb",
+    "address": "0x54edd846db17f43b6e43296134ecd96284671e81",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x8ff795a6f4d97e7887c79bea79aba5cc76444adf",
+      "oracle": "pancake",
+      "oracleId": "BCH",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-dai-busd",
+    "address": "0x3ab77e40340ab084c3e23be8e5a6f7afed9d41dc",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3",
+      "oracle": "pancake",
+      "oracleId": "DAI",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+      "oracle": "pancake",
+      "oracleId": "BUSD",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-kebab-busd",
+    "address": "0xd51bee2e0a3886289f6d229b6f30c0c2b34fc0ec",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x7979f6c54eba05e18ded44c4f986f49a5de551c2",
+      "oracle": "pancake",
+      "oracleId": "KEBAB",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+      "oracle": "pancake",
+      "oracleId": "BUSD",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-bifi-wbnb",
+    "address": "0xd132d2c24f29ee8abb64a66559d1b7aa627bd7fd",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0xca3f508b8e4dd382ee878a314789373d80a5190a",
+      "oracle": "pancake",
+      "oracleId": "BIFI",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-ust-busd",
+    "address": "0xd1f12370b2ba1c79838337648f820a87edf5e1e6",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x23396cf899ca06c4472205fc903bdb4de249d6fc",
+      "oracle": "pancake",
+      "oracleId": "UST",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+      "oracle": "pancake",
+      "oracleId": "BUSD",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-cake-bnb",
+    "address": "0xA527a61703D82139F8a06Bc30097cC9CAA2df5A6",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82",
+      "oracle": "pancake",
+      "oracleId": "Cake",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "cake-busd-bnb",
+    "address": "0x1B96B92314C44b159149f7E0303511fB2Fc4774f",
+    "decimals": "1e18",
+    "lp0": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "pancake",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+      "oracle": "pancake",
+      "oracleId": "BUSD",
+      "decimals": "1e18"
+    }
+  }
+]

--- a/src/router.js
+++ b/src/router.js
@@ -21,7 +21,7 @@ router.get('/supply/circulating', supply.circulating);
 router.get('/earnings', gov.earnings);
 router.get('/holders', gov.holderCount);
 
-router.get('/pancake/price', proxy.pancake);
+router.get('/pancake/price', price.pancakePrices);
 router.get('/thugs/tickers', proxy.thugs);
 router.get('/bakery/price', price.bakeryPrices);
 router.get('/nyanswop/price', price.nyanswopPrices);


### PR DESCRIPTION
Added Pancake's LP data to read prices from. New output fits usages of pancake oracle in https://github.com/beefyfinance/beefy-app/blob/master/src/features/configure/pools.js
+ UST, mTSLA, mNFLX, mGOOGL, mAMZN

Current response:
```
{
   "BUSD":1,
   "WBNB":331.89167975953063,
   "Cake":18.860451349008063,
   "UST":1.0156683370856026,
   "BIFI":1917.2814568952108,
   "KEBAB":24.849213760351972,
   "DAI":1.003107317448465,
   "BCH":720.2132122809014,
   "SXP":3.4876489346426225,
   "USDC":0.9994632394794822,
   "FIL":43.40235106343949,
   "XRP":0.5645453247713679,
   "BAKE":2.6843402122784017,
   "Fuel":896.9806428306168,
   "LINK":34.65247629961246,
   "ETH":1954.8679546564572,
   "USDT":0.9992977244084521,
   "BTCB":55956.31233697543,
   "XVS":91.83289996751589,
   "TWT":0.8658356345667776,
   "INJ":16.96262068213209,
   "ALPHA":1.5533552489306692,
   "PSG":13.578164940461418,
   "bROOBEE":0.0057708793686234855,
   "VAI":0.9813129140296066,
   "ATOM":22.923771707883958,
   "BAND":18.017926206870943,
   "YFI":44671.43366634581,
   "YFII":3527.8963861213115,
   "CTK":2.673359191089005,
   "NYA":0.027733238731835218,
   "NAR":0.42839439230621235,
   "STAX":1.9130799603743274,
   "REEF":0.03737005850552813,
   "UNFI":26.741029464917634,
   "BSCX":25.490019239054906,
   "bALBT":0.8421970441439159,
   "TEN":4.646053737989901,
   "DOT":34.98135923675877,
   "ADA":0.9268561198196928,
   "LTC":236.45263092640073,
   "BTCST":230.19557357293468,
   "Helmet":1.7278687295052524,
   "FRONT":3.845337748580665,
   "wSOTE":4.907041987812654,
   "mTSLA":807.1527527198103,
   "mNFLX":553.1653389145489,
   "mGOOGL":2160.3488701771334,
   "mAMZN":3363.455232036614,
   "EGLD":140.29158168709316,
   "BDO":1.1535459014118237,
   "HGET":14.360631521375195,
   "DITTO":1.498317319703254,
   "HARD":2.3739757599417417,
   "LIT":10.289790285456986,
   "SWGb":0.8345500934299257,
   "LINA":0.08775636353073595,
   "ZEE":1.4243972955699067,
   "BRY":38.98755289193549,
   "COMP":460.32148486362,
   "SWINGBY":0.9750908236745882
}
```