### PR TITLE
fix: remove redundant await for not-async method

### DIFF
--- a/src/api/stats/bhc/getBhcPoolApy.js
+++ b/src/api/stats/bhc/getBhcPoolApy.js
@@ -28,7 +28,7 @@ const getBhcPoolApy = async () => {
 };
 
 const getTotalStakedInUsd = async () => {
-  const tokenContract = await new web3.eth.Contract(IRewardPool, stakingPool);
+  const tokenContract = new web3.eth.Contract(IRewardPool, stakingPool);
   const totalStaked = new BigNumber(await tokenContract.methods.totalSupply().call());
   const tokenPrice = await fetchPrice({ oracle, id: oracleId });
   return totalStaked.times(tokenPrice).dividedBy(DECIMALS);

--- a/src/api/stats/julb/getJuldPoolApy.js
+++ b/src/api/stats/julb/getJuldPoolApy.js
@@ -26,7 +26,7 @@ const getJulDPoolApy = async () => {
 };
 
 const getTotalStakedInUsd = async () => {
-  const tokenContract = await new web3.eth.Contract(IRewardPool, stakingPool);
+  const tokenContract = new web3.eth.Contract(IRewardPool, stakingPool);
   const totalStaked = new BigNumber(await tokenContract.methods.totalSupply().call());
   const tokenPrice = await fetchPrice({ oracle, id: oracleId });
   return totalStaked.times(tokenPrice).dividedBy(DECIMALS);

--- a/src/api/stats/nyanswop/getNyanswopPrice.js
+++ b/src/api/stats/nyanswop/getNyanswopPrice.js
@@ -75,13 +75,13 @@ const getTokenPriceInUsd = async (
   knownPriceTokenPriceUnit,
   decimals = '1e18'
 ) => {
-  const knownPriceTokenContract = await new web3.eth.Contract(ERC20, knownPriceToken.address);
+  const knownPriceTokenContract = new web3.eth.Contract(ERC20, knownPriceToken.address);
   const knownPriceTokenTotalStaked = new BigNumber(
     await knownPriceTokenContract.methods.balanceOf(lpContract).call()
   );
   const knownPriceTokenTotalStakedUsdt = knownPriceTokenTotalStaked.times(knownPriceTokenPriceUnit); // half value of entire LP
 
-  const unknownPriceTokenContract = await new web3.eth.Contract(ERC20, unknownPriceToken.address);
+  const unknownPriceTokenContract = new web3.eth.Contract(ERC20, unknownPriceToken.address);
   const unknownPriceTokenTotalStaked = new BigNumber(
     await unknownPriceTokenContract.methods.balanceOf(lpContract).call()
   );

--- a/src/utils/getTotalStakedInUsd.js
+++ b/src/utils/getTotalStakedInUsd.js
@@ -15,7 +15,7 @@ const getTotalStakedInUsd = async (
 ) => {
   const web3 = web3Factory(chainId);
 
-  const tokenContract = await new web3.eth.Contract(ERC20, tokenAddr);
+  const tokenContract = new web3.eth.Contract(ERC20, tokenAddr);
   const totalStaked = new BigNumber(await tokenContract.methods.balanceOf(targetAddr).call());
   const tokenPrice = await fetchPrice({ oracle, id: oracleoId });
   return totalStaked.times(tokenPrice).dividedBy(decimals);
@@ -24,7 +24,7 @@ const getTotalStakedInUsd = async (
 const getTotalLpStakedInUsd = async (targetAddr, pool, chainId = 56) => {
   const web3 = web3Factory(chainId);
 
-  const tokenPairContract = await new web3.eth.Contract(ERC20, pool.address);
+  const tokenPairContract = new web3.eth.Contract(ERC20, pool.address);
   const totalStaked = new BigNumber(await tokenPairContract.methods.balanceOf(targetAddr).call());
   const tokenPrice = await lpTokenPrice(pool);
   const totalStakedInUsd = totalStaked.times(tokenPrice).dividedBy('1e18');

--- a/src/utils/lpTokens.js
+++ b/src/utils/lpTokens.js
@@ -6,9 +6,9 @@ const ERC20 = require('../abis/ERC20.json');
 const lpTokenPrice = async lpToken => {
   const web3 = web3Factory(lpToken.chainId || 56);
 
-  const tokenPairContract = await new web3.eth.Contract(ERC20, lpToken.address);
-  const token0Contract = await new web3.eth.Contract(ERC20, lpToken.lp0.address);
-  const token1Contract = await new web3.eth.Contract(ERC20, lpToken.lp1.address);
+  const tokenPairContract = new web3.eth.Contract(ERC20, lpToken.address);
+  const token0Contract = new web3.eth.Contract(ERC20, lpToken.lp0.address);
+  const token1Contract = new web3.eth.Contract(ERC20, lpToken.lp1.address);
 
   let [totalSupply, reserve0, reserve1, token0Price, token1Price] = await Promise.all([
     tokenPairContract.methods.totalSupply().call(),

--- a/src/utils/lpTokensRatio.js
+++ b/src/utils/lpTokensRatio.js
@@ -5,7 +5,7 @@ const LPPair = require('../abis/LPPair.json');
 const lpTokenRatio = async (lpTokenAddress, decimals0, decimals1, chainId = 56) => {
   const web3 = web3Factory(chainId);
 
-  const tokenPairContract = await new web3.eth.Contract(LPPair, lpTokenAddress);
+  const tokenPairContract = new web3.eth.Contract(LPPair, lpTokenAddress);
 
   let { _reserve0, _reserve1 } = await tokenPairContract.methods.getReserves().call();
   const reserve0 = new BigNumber(_reserve0);


### PR DESCRIPTION
Currently we are using `await` for non async calls of `new web3.eth.Contract(ERC20, tokenAddr)`, this method returns object, not promise. Therefor usage of `await` is a misleading error.
 
From web3-eth lib:
```
export class Eth {
    ...
    Contract: new (
        jsonInterface: AbiItem[] | AbiItem,
        address?: string,
        options?: ContractOptions
    ) => Contract;
```