### PR TITLE
refactoring: remove old prices endpoints

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,9 +34,9 @@ yarn start
 
 After you start the API it can take a minute or two before you can fetch the APYs. We currently log `getApys()` to the console when all the data is available.
 
-**/:platform/price**: We have a few different endpoints to fetch price oracle information of different assets. We get most token prices from "/pancake/price" but there are some exceptions that come from "/bakery/price" for example. The intention is to eventually unify all token prices under the same endpoint.
+**/prices**: All token prices under the same endpoint (crosschain).
 
-**/:platform/lps**: We have a single endpoint per platform we farm to get its LP token prices. For example "kebab/lps" gives all the price info about the kebab LPs. Just like with the previous endpoint, we want to unify all LP prices under a single endpoint.
+**/lps**: All liqudity pair prices under a single endpoint (crosschain).
 
 ### Consumed by third party platforms
 

--- a/src/api/price/index.js
+++ b/src/api/price/index.js
@@ -1,130 +1,10 @@
 const { getAmmTokensPrices, getAmmLpPrices } = require('../stats/getAmmPrices');
 
-// TODO: Remove all imports below in favor of getAmmPrices
-const { lpTokenPrices } = require('../../utils/lpTokens');
-const fetchPrice = require('../../utils/fetchPrice');
-const thugsLpTokens = require('../../data/thugsLpPools.json');
-const bakeryLpTokens = require('../../data/bakeryLpPools.json');
-const narLpTokens = require('../../data/narLpPools.json');
-const jetfuelLpTokens = require('../../data/jetfuelLpPools.json');
-const bdollarBdoLpTokens = require('../../data/bdollarBdoLpPools.json');
-const bdollarSbdoLpTokens = require('../../data/bdollarSbdoLpPools.json');
-const helmetLpTokens = require('../../data/helmetLpPools.json');
-const kebabLpTokens = require('../../data/kebabLpPools.json');
-const monsterLpTokens = require('../../data/monsterLpPools.json');
-const nyanswopLpTokens = require('../../data/nyanswopLpPools.json');
-const spongeLpTokens = require('../../data/spongeLpPools.json');
-const mdexLpTokens = require('../../data/mdexLpPools.json');
-const boltBtdLpTokens = require('../../data/boltBtdLpPools.json');
-const boltBtsLpTokens = require('../../data/boltBtsLpPools.json');
-const crowLpTokens = require('../../data/crowLpPools.json');
-const midasLpTokens = require('../../data/midasLpPools.json');
-const cafeLpTokens = require('../../data/cafeLpPools.json');
-const ramenLpTokens = require('../../data/ramenLpPools.json');
-
 async function lpsPrices(ctx) {
   try {
     const lpTokenPrices = await getAmmLpPrices();
     ctx.status = 200;
     ctx.body = lpTokenPrices;
-  } catch (err) {
-    console.error(err);
-    ctx.status = 500;
-  }
-}
-
-async function lpPrices(ctx, lpTokens) {
-  try {
-    const prices = await lpTokenPrices(lpTokens);
-    ctx.status = 200;
-    ctx.body = prices;
-  } catch (err) {
-    console.error(err);
-    ctx.status = 500;
-  }
-}
-
-async function thugsLpPrices(ctx) {
-  await lpPrices(ctx, thugsLpTokens);
-}
-
-async function bakeryLpPrices(ctx) {
-  await lpPrices(ctx, bakeryLpTokens);
-}
-
-async function narLpPrices(ctx) {
-  await lpPrices(ctx, narLpTokens);
-}
-
-async function jetfuelLpPrices(ctx) {
-  await lpPrices(ctx, jetfuelLpTokens);
-}
-
-async function bdollarLpPrices(ctx) {
-  await lpPrices(ctx, [...bdollarBdoLpTokens, ...bdollarSbdoLpTokens]);
-}
-
-async function helmetLpPrices(ctx) {
-  await lpPrices(ctx, helmetLpTokens);
-}
-
-async function kebabLpPrices(ctx) {
-  await lpPrices(ctx, kebabLpTokens);
-}
-
-async function monsterLpPrices(ctx) {
-  await lpPrices(ctx, monsterLpTokens);
-}
-
-async function nyanswopLpPrices(ctx) {
-  await lpPrices(ctx, nyanswopLpTokens);
-}
-
-async function spongeLpPrices(ctx) {
-  await lpPrices(ctx, spongeLpTokens);
-}
-
-async function mdexLpPrices(ctx) {
-  await lpPrices(ctx, mdexLpTokens);
-}
-
-async function boltLpPrices(ctx) {
-  await lpPrices(ctx, boltBtdLpTokens);
-  await lpPrices(ctx, [...boltBtdLpTokens, ...boltBtsLpTokens]);
-}
-
-async function crowLpPrices(ctx) {
-  await lpPrices(ctx, crowLpTokens);
-}
-
-async function midasLpPrices(ctx) {
-  await lpPrices(ctx, midasLpTokens);
-}
-
-async function cafeLpPrices(ctx) {
-  await lpPrices(ctx, cafeLpTokens);
-}
-
-async function ramenLpPrices(ctx) {
-  await lpPrices(ctx, ramenLpTokens);
-}
-
-async function bakeryPrices(ctx) {
-  try {
-    const price = await fetchPrice({ oracle: 'coingecko', id: 'binance-eth' });
-    ctx.status = 200;
-    ctx.body = { BETH: price };
-  } catch (err) {
-    console.error(err);
-    ctx.status = 500;
-  }
-}
-
-async function nyanswopPrices(ctx) {
-  try {
-    const prices = await getAmmTokensPrices();
-    ctx.status = 200;
-    ctx.body = prices;
   } catch (err) {
     console.error(err);
     ctx.status = 500;
@@ -144,22 +24,4 @@ async function tokenPrices(ctx) {
 module.exports = {
   lpsPrices,
   tokenPrices,
-  thugsLpPrices,
-  bakeryLpPrices,
-  narLpPrices,
-  jetfuelLpPrices,
-  bdollarLpPrices,
-  bakeryPrices,
-  nyanswopPrices,
-  helmetLpPrices,
-  kebabLpPrices,
-  monsterLpPrices,
-  nyanswopLpPrices,
-  spongeLpPrices,
-  boltLpPrices,
-  mdexLpPrices,
-  crowLpPrices,
-  midasLpPrices,
-  cafeLpPrices,
-  ramenLpPrices,
 };

--- a/src/api/stats/fortube/getFortubeApys.js
+++ b/src/api/stats/fortube/getFortubeApys.js
@@ -8,6 +8,10 @@ const {
 } = require('../../../../constants');
 
 const getFortubeApys = async () => {
+  if (FORTUBE_API_TOKEN == undefined) {
+    return console.warn('FORTUBE_API_TOKEN is undefined, skip loading Fortube APYs')
+  }
+
   let fortubeApys = {};
 
   try {

--- a/src/api/stats/getAmmPrices.js
+++ b/src/api/stats/getAmmPrices.js
@@ -103,11 +103,29 @@ const getAmmLpPrices = async () => {
   return lpPricesCache;
 };
 
+const getAmmTokenPrice = async (tokenSymbol) => {
+  const tokenPrices = await getAmmTokensPrices();
+  if (tokenPrices.hasOwnProperty(tokenSymbol)) {
+    return tokenPrices[tokenSymbol]
+  }
+  throw new Error(`Unknown token '${tokenSymbol}'. Consider adding it to .json file`);
+};
+
+const getAmmLpPrice = async (lpName) => {
+  const lpPrices = await getAmmLpPrices();
+  if (lpPrices.hasOwnProperty(lpName)) {
+    return lpPrices[lpName]
+  }
+  throw new Error(`Unknown liqudity pair '${lpName}'. Consider adding it to .json file`);
+};
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 module.exports = {
+  getAmmTokenPrice,
   getAmmTokensPrices,
+  getAmmLpPrice,
   getAmmLpPrices,
 };

--- a/src/router.js
+++ b/src/router.js
@@ -25,28 +25,6 @@ router.get('/stake', stake.data);
 router.get('/lps', price.lpsPrices);
 router.get('/prices', price.tokenPrices);
 
-router.get('/pancake/price', price.tokenPrices);
-router.get('/bakery/price', price.bakeryPrices);
-router.get('/nyanswop/price', price.tokenPrices);
-
-router.get('/pancake/lps', price.lpsPrices);
-router.get('/thugs/lps', price.thugsLpPrices);
-router.get('/bakery/lps', price.bakeryLpPrices);
-router.get('/narwhal/lps', price.narLpPrices);
-router.get('/jetfuel/lps', price.jetfuelLpPrices);
-router.get('/bdollar/lps', price.bdollarLpPrices);
-router.get('/helmet/lps', price.helmetLpPrices);
-router.get('/kebab/lps', price.kebabLpPrices);
-router.get('/monster/lps', price.monsterLpPrices);
-router.get('/nyanswop/lps', price.nyanswopLpPrices);
-router.get('/sponge/lps', price.spongeLpPrices);
-router.get('/mdex/lps', price.mdexLpPrices);
-router.get('/bolt/lps', price.boltLpPrices);
-router.get('/crow/lps', price.crowLpPrices);
-router.get('/midas/lps', price.midasLpPrices);
-router.get('/cafe/lps', price.cafeLpPrices);
-router.get('/ramen/lps', price.ramenLpPrices);
-
 router.get('/', noop);
 
 module.exports = router;

--- a/src/utils/fetchPrice.js
+++ b/src/utils/fetchPrice.js
@@ -1,28 +1,8 @@
 const axios = require('axios');
-const { API_BASE_URL } = require('../../constants');
-const { lpTokenRatio } = require('./lpTokensRatio');
-const { getAmmTokensPrices } = require('../api/stats/getAmmPrices');
+const { getAmmTokenPrice, getAmmLpPrice } = require('../api/stats/getAmmPrices');
 
-const endpoints = {
-  bakery: `${API_BASE_URL}/bakery/price`,
-  bakeryLp: `${API_BASE_URL}/bakery/lps`,
-  bdollarLp: `${API_BASE_URL}/bdollar/lps`,
-  coingecko: `https://api.coingecko.com/api/v3/simple/price`,
-  jetfuelLp: `${API_BASE_URL}/jetfuel/lps`,
-  narwhalLp: `${API_BASE_URL}/narwhal/lps`,
-  pancakeLp: `${API_BASE_URL}/pancake/lps`,
-  pancake: `${API_BASE_URL}/pancake/price`,
-  thugsLp: `${API_BASE_URL}/thugs/lps`,
-  thugsLp: `${API_BASE_URL}/thugs/lps`,
-  lps: `${API_BASE_URL}/lps`,
-};
-
-const CACHE_TIMEOUT = 30 * 60 * 1000;
+const CACHE_TIMEOUT = 10 * 60 * 1000;
 const cache = {};
-
-const WBNB = '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c';
-const BUSD = '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56';
-const WBNB_BUSD = `${WBNB}_${BUSD}`;
 
 function isCached({ oracle, id }) {
   if (`${oracle}-${id}` in cache) {
@@ -41,27 +21,12 @@ function addToCache({ oracle, id, price }) {
 
 const fetchCoingecko = async id => {
   try {
-    const response = await axios.get(endpoints.coingecko, {
+    const response = await axios.get('https://api.coingecko.com/api/v3/simple/price', {
       params: { ids: id, vs_currencies: 'usd' },
     });
     return response.data[id].usd;
   } catch (err) {
     console.error('fetchCoingecko error:', err);
-    return 0;
-  }
-};
-
-const fetchPancake = async id => {
-  const cakePrices = await getAmmTokensPrices();
-  return cakePrices[id] || 0;
-};
-
-const fetchLP = async (id, endpoint) => {
-  try {
-    const response = await axios.get(endpoint);
-    return response.data[id];
-  } catch (err) {
-    console.error('fetchLP error:', id, err);
     return 0;
   }
 };
@@ -100,20 +65,6 @@ const fetchMirror = async id => {
   }
 };
 
-const fetchBakery = async id => {
-  if (id !== 'BETH') return 0;
-  try {
-    const bakeryWbnbBethLp = '0x2fc2ad3c28560c97caca6d2dcf9b38614f48769a';
-    const ratio = await lpTokenRatio(bakeryWbnbBethLp, '1e18', '1e18');
-    const bnbPrice = await fetchPrice({ oracle: 'pancake', id: 'WBNB' });
-    const bethPrice = bnbPrice / ratio;
-    return bethPrice;
-  } catch (err) {
-    console.error(err);
-    return 0;
-  }
-};
-
 const fetchPrice = async ({ oracle, id }) => {
   if (oracle === undefined) {
     console.error('Undefined oracle');
@@ -130,62 +81,37 @@ const fetchPrice = async ({ oracle, id }) => {
 
   let price = 0;
   switch (oracle) {
-    case 'bakery':
-      price = await fetchLP(id, endpoints.bakery);
-      break;
-
-    case 'bakery-lp':
-      price = await fetchLP(id, endpoints.bakeryLp);
-      break;
-
-    case 'bdollar-lp':
-      price = await fetchLP(id, endpoints.bdollarLp);
-      break;
-
     case 'coingecko':
       price = await fetchCoingecko(id);
       break;
 
+    case 'lps':
+    case 'bakery-lp':
+    case 'bdollar-lp':
     case 'jetfuel-lp':
-      price = await fetchLP(id, endpoints.jetfuelLp);
-      break;
-
     case 'narwhal-lp':
-      price = await fetchLP(id, endpoints.narwhalLp);
+    case 'thugs-lp':
+      price = await getAmmLpPrice(id);
       break;
 
+    case 'thugs':
+    case 'bakery':
     case 'mdex':
     case 'nyanswop':
     case 'pancake':
-      price = await fetchPancake(id);
-      break;
-
-    case 'pancake-lp':
-      price = await fetchLP(id, endpoints.pancakeLp);
-      break;
-
-    case 'thugs-lp':
-      price = await fetchLP(id, endpoints.thugsLp);
+      price = await getAmmTokenPrice(id);
       break;
 
     case 'hardcode':
       price = id;
       break;
 
-    case 'bakery':
-      price = await fetchBakery(id);
-      break;
-
     case 'mirror':
       price = await fetchMirror(id);
       break;
 
-    case 'lps':
-      price = await fetchLP(id, endpoints.lps);
-      break;
-
     default:
-      price = 0;
+      throw new Error(`Oracle '${oracle}' not implemented`)
   }
 
   addToCache({ oracle, id, price });

--- a/src/utils/lpTokens.js
+++ b/src/utils/lpTokens.js
@@ -53,6 +53,7 @@ const lpTokenPrices = async lpTokens => {
 };
 
 const lpTokenStats = async lpToken => {
+  // TODO: Refactor price calls to use getAmmPrices
   const lpPrice = await lpTokenPrice(lpToken);
   return { [lpToken.name]: lpPrice };
 };


### PR DESCRIPTION
Finishes #61

- [x] Remove `/:platform/price` endpoints
- [x] Remove `/:platform/lps` endpoints
- [x] Strict oracle/oracleId to catch 0 prices in development
- [x] Skip loading Fortube APY if API key undefined