### PR TITLE
Switch to pancake oracle for JulD

### DIFF
--- a/src/data/julLpPools.json
+++ b/src/data/julLpPools.json
@@ -6,8 +6,8 @@
     "poolId": 0,
     "lp0": {
       "address": "0x5A41F637C3f7553dBa6dDC2D3cA92641096577ea",
-      "oracle": "coingecko",
-      "oracleId": "julswap",
+      "oracle": "pancake",
+      "oracleId": "JULD",
       "decimals": "1e18"
     },
     "lp1": {


### PR DESCRIPTION
JULD-BNB not calculating TVL due to it missing in lps. The AMM file isn't reading the coingecko oracle, switching to pancake to fix. 