### PR TITLE
Optimize get block request

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -7,6 +7,16 @@ const MAINNET_BSC_RPC_ENDPOINTS = [
   'https://bsc-dataseed.binance.org',
   'https://bsc-dataseed1.defibit.io',
   'https://bsc-dataseed1.ninicoin.io',
+  'https://bsc-dataseed2.defibit.io',
+  'https://bsc-dataseed3.defibit.io',
+  'https://bsc-dataseed4.defibit.io',
+  'https://bsc-dataseed2.ninicoin.io',
+  'https://bsc-dataseed3.ninicoin.io',
+  'https://bsc-dataseed4.ninicoin.io',
+  'https://bsc-dataseed1.binance.org',
+  'https://bsc-dataseed2.binance.org',
+  'https://bsc-dataseed3.binance.org',
+  'https://bsc-dataseed4.binance.org',
 ];
 
 const CUSTOM_BSC_RPC_ENDPOINTS = [

--- a/src/api/stats/alpaca/getYearlyRewardsInUsd.js
+++ b/src/api/stats/alpaca/getYearlyRewardsInUsd.js
@@ -3,9 +3,11 @@ const { bscWeb3: web3 } = require('../../../utils/web3');
 
 const FairLaunch = require('../../../abis/FairLaunch.json');
 const fetchPrice = require('../../../utils/fetchPrice');
+const getBlockNumber = require('../../../utils/getBlockNumber');
+const { BSC_CHAIN_ID } = require('../../../../constants');
 
 const getYearlyRewardsInUsd = async (fairLaunch, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const fairLaunchContract = new web3.eth.Contract(FairLaunch, fairLaunch);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/bakery/getYearlyRewardsInUsd.js
+++ b/src/api/stats/bakery/getYearlyRewardsInUsd.js
@@ -3,9 +3,11 @@ const { bscWeb3: web3 } = require('../../../utils/web3');
 
 const IBakeryMaster = require('../../../abis/IBakeryMaster.json');
 const fetchPrice = require('../../../utils/fetchPrice');
+const getBlockNumber = require('../../../utils/getBlockNumber');
+const { BSC_CHAIN_ID } = require('../../../../constants');
 
 const getYearlyRewardsInUsd = async (bakeryMaster, asset) => {
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID);
   const bakeryMasterContract = new web3.eth.Contract(IBakeryMaster, bakeryMaster);
 
   let [blockRewards, totalAllocPoint] = await Promise.all([

--- a/src/api/stats/bdollar/getBdoLpApys.js
+++ b/src/api/stats/bdollar/getBdoLpApys.js
@@ -6,7 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/bdollarBdoLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getBdoLpApys = async () => {
   let apys = {};
@@ -34,7 +35,7 @@ const getPoolApy = async (bdoRewardPool, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (bdoRewardPool, poolId) => {
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID);
   const bdoRewardPoolContract = new web3.eth.Contract(BdoRewardPool, bdoRewardPool);
 
   let [blockRewards, totalAllocPoint] = await Promise.all([

--- a/src/api/stats/bdollar/getSbdoLpApys.js
+++ b/src/api/stats/bdollar/getSbdoLpApys.js
@@ -6,7 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/bdollarSbdoLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getBdoLpApys = async () => {
   let apys = {};
@@ -35,7 +36,7 @@ const getPoolApy = async (sbdoRewardPool, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (sbdoRewardPool, poolId) => {
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID);
   const bdoRewardPoolContract = new web3.eth.Contract(SbdoRewardPool, sbdoRewardPool);
 
   let [blockRewards, totalAllocPoint] = await Promise.all([

--- a/src/api/stats/belt/getBeltApys.js
+++ b/src/api/stats/belt/getBeltApys.js
@@ -7,6 +7,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/beltPools.json');
 const { compound } = require('../../../utils/compound');
 const getBeltVenusLpPrice = require('./getBeltVenusLpPrice');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterbelt = '0xD4BbC80b9B102b77B21A06cb77E954049605E6c1';
 const oracleId = 'BELT';
@@ -55,7 +57,7 @@ const getTotalLpStakedInUsd = async (masterbelt, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterbelt, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterbeltContract = new web3.eth.Contract(MasterBelt, masterbelt);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/bolt/getBtdLpApys.js
+++ b/src/api/stats/bolt/getBtdLpApys.js
@@ -6,7 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/boltBtdLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getBtdLpApys = async () => {
   let apys = {};
@@ -35,7 +36,7 @@ const getPoolApy = async (btsRewardPool, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (btsRewardPool, poolId) => {
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID)
   const btdRewardPoolContract = new web3.eth.Contract(BtdRewardPool, btsRewardPool);
 
   let [blockRewards, totalAllocPoint] = await Promise.all([

--- a/src/api/stats/bolt/getBtsLpApys.js
+++ b/src/api/stats/bolt/getBtsLpApys.js
@@ -6,7 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/boltBtsLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getBtsLpApys = async () => {
   let apys = {};
@@ -35,7 +36,7 @@ const getPoolApy = async (btsRewardPool, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (btsRewardPool, poolId) => {
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID);
   const btsRewardPoolContract = new web3.eth.Contract(BtsRewardPool, btsRewardPool);
 
   let [blockRewards, totalAllocPoint] = await Promise.all([

--- a/src/api/stats/cafe/getCafeLpApys.js
+++ b/src/api/stats/cafe/getCafeLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/cafeLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getCafeLpApys = async () => {
   let apys = {};
@@ -33,7 +35,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/complus/getComAvaxLpApys.js
+++ b/src/api/stats/complus/getComAvaxLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/comAvaxLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { AVAX_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0xa329D806fbC80a14415588334ae4b205813C6BB2';
 const oracleId = 'COM';
@@ -39,7 +41,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(AVAX_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/complus/getComBscLpApys.js
+++ b/src/api/stats/complus/getComBscLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/comBscLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0x110650bBAfCe4Ec7e864fe4A4A88BBD4AF547159';
 const oracleId = 'bCOM';
@@ -39,7 +41,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/crow/getCrowLpApys.js
+++ b/src/api/stats/crow/getCrowLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/crowLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getCrowLpApys = async () => {
   let apys = {};
@@ -33,7 +35,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   /*   const multiplier = new BigNumber(

--- a/src/api/stats/degens/getApeBananaApy.js
+++ b/src/api/stats/degens/getApeBananaApy.js
@@ -5,7 +5,8 @@ const MasterChef = require('../../../abis/MasterChef.json');
 const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
 const { compound } = require('../../../utils/compound');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getApeBananaApy = async () => {
   const masterChef = '0x5c8d727b265dbafaba67e050f2f739caeeb4a6f9';
@@ -25,7 +26,7 @@ const getApeBananaApy = async () => {
 };
 
 const getYearlyRewardsInUsd = async (masterChefAddr, oracle, oracleId) => {
-  const fromBlock = await web3.eth.getBlockNumber();
+  const fromBlock = await getBlockNumber(BSC_CHAIN_ID);
   const toBlock = fromBlock + 1;
   const masterChefContract = new web3.eth.Contract(MasterChef, masterChefAddr);
 

--- a/src/api/stats/degens/getApeLpApys.js
+++ b/src/api/stats/degens/getApeLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/degens/apeLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0x5c8d727b265dbafaba67e050f2f739caeeb4a6f9';
 const oracleId = 'BANANA';
@@ -37,7 +39,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/degens/getBlizzardApy.js
+++ b/src/api/stats/degens/getBlizzardApy.js
@@ -5,7 +5,8 @@ const MasterChef = require('../../../abis/degens/BlizzardMasterChef.json');
 const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
 const { compound } = require('../../../utils/compound');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getBlizzardApy = async () => {
   const masterChef = '0x2078F4A75c92A6918D13e3e2F14183443ebf55D3';
@@ -25,7 +26,7 @@ const getBlizzardApy = async () => {
 };
 
 const getYearlyRewardsInUsd = async (masterChefAddr, oracle, oracleId) => {
-  const fromBlock = await web3.eth.getBlockNumber();
+  const fromBlock = await getBlockNumber(BSC_CHAIN_ID);
   const toBlock = fromBlock + 1;
   const masterChefContract = new web3.eth.Contract(MasterChef, masterChefAddr);
 

--- a/src/api/stats/degens/getBlizzardLpApys.js
+++ b/src/api/stats/degens/getBlizzardLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/degens/blizzardLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0x2078F4A75c92A6918D13e3e2F14183443ebf55D3';
 const oracleId = 'BLZD';
@@ -37,7 +39,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/degens/getMasterChefApys.js
+++ b/src/api/stats/degens/getMasterChefApys.js
@@ -4,6 +4,8 @@ const { bscWeb3: web3 } = require('../../../utils/web3');
 const fetchPrice = require('../../../utils/fetchPrice');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getMasterChefApys = async (masterchef, masterChefAbi, tokenPerBlock, pools, oracle, oracleId, decimals) => {
   let apys = {};
@@ -31,7 +33,7 @@ const getPoolApy = async (masterchef, masterChefAbi, tokenPerBlock, pool, oracle
 };
 
 const getYearlyRewardsInUsd = async (masterchef, masterChefAbi, pool, tokenPerBlock, oracle, oracleId, decimals) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(masterChefAbi, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/degens/getMemeFarmLpApys.js
+++ b/src/api/stats/degens/getMemeFarmLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/degens/memeFarmLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0xa0A4Ab8c15c5b7C9f0d73a23786B5B51BA2d5399';
 const oracleId = 'MFRM';
@@ -37,7 +39,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/degens/getNautApy.js
+++ b/src/api/stats/degens/getNautApy.js
@@ -5,7 +5,8 @@ const SmartChef = require('../../../abis/SmartChef.json');
 const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
 const { compound } = require('../../../utils/compound');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const smartChef = '0x114d54e18eb4A7Dc9bB8280e283E5799D4188E3f';
 const oracle = 'tokens';
@@ -32,7 +33,7 @@ const getNautApy = async () => {
 const getYearlyRewardsInUsd = async (smartChefAddr, oracle, oracleId, decimals) => {
   const smartChefContract = new web3.eth.Contract(SmartChef, smartChefAddr);
 
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID);
   const bonusEndBlock = await smartChefContract.methods.bonusEndBlock().call();
   const isPoolRunning = currentBlock <= bonusEndBlock;
 

--- a/src/api/stats/degens/getSaltLpApys.js
+++ b/src/api/stats/degens/getSaltLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/degens/saltLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0xB4405445fFAcF2B86BC2bD7D1C874AC739265658';
 const oracleId = 'SALT';
@@ -37,7 +39,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/degens/getSlimeLpApys.js
+++ b/src/api/stats/degens/getSlimeLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/degens/slimeLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0x4b0073a79f2b46ff5a62fa1458aac86ed918c80c';
 const oracleId = 'SLIME';
@@ -37,7 +39,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/degens/getSpaceLpApys.js
+++ b/src/api/stats/degens/getSpaceLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/degens/spaceLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0xc8cf0767fB2258b23B90636A5e21cfaD113e8182';
 const oracleId = 'SPACE';
@@ -38,7 +40,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/jetfuel/getJetfuelLpApys.js
+++ b/src/api/stats/jetfuel/getJetfuelLpApys.js
@@ -6,7 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/jetfuelLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getJetfuelLpApys = async () => {
   let apys = {};
@@ -36,7 +37,7 @@ const getPoolApy = async (masterFuel, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterFuel, poolId) => {
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID);
   const masterFuelContract = new web3.eth.Contract(MasterFuel, masterFuel);
 
   let [blockRewards, totalAllocPoint] = await Promise.all([

--- a/src/api/stats/kebab/getKebabLpApys.js
+++ b/src/api/stats/kebab/getKebabLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/kebabLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getKebabLpApys = async () => {
   let apys = {};
@@ -33,7 +35,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/kebab/getKebabPoolApy.js
+++ b/src/api/stats/kebab/getKebabPoolApy.js
@@ -5,6 +5,8 @@ const MasterChef = require('../../../abis/MasterChef.json');
 const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
 const { compound } = require('../../../utils/compound');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getKebabPoolApy = async () => {
   const masterChef = '0x76fcefffcf5325c6156ca89639b17464ea833ecd';
@@ -24,7 +26,7 @@ const getKebabPoolApy = async () => {
 };
 
 const getYearlyRewardsInUsd = async (masterChefAddr, oracle, oracleId) => {
-  const fromBlock = await web3.eth.getBlockNumber();
+  const fromBlock = await getBlockNumber(BSC_CHAIN_ID);
   const toBlock = fromBlock + 1;
   const masterChefContract = new web3.eth.Contract(MasterChef, masterChefAddr);
 

--- a/src/api/stats/midas/getMidasLpApys.js
+++ b/src/api/stats/midas/getMidasLpApys.js
@@ -6,7 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/midasLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getMidasLpApys = async () => {
   let apys = {};
@@ -35,7 +36,7 @@ const getPoolApy = async (shareRewardPool, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (shareRewardPool, poolId) => {
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID);
   const rewardPoolContract = new web3.eth.Contract(ShareRewardPool, shareRewardPool);
 
   let [blockRewards, totalAllocPoint] = await Promise.all([

--- a/src/api/stats/narwhal/getNarLpApys.js
+++ b/src/api/stats/narwhal/getNarLpApys.js
@@ -6,7 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/narLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getNarLpApys = async () => {
   let apys = {};
@@ -34,7 +35,7 @@ const getPoolApy = async (goldFarm, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (goldFarm, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const goldFarmContract = new web3.eth.Contract(IGoldFarm, goldFarm);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/pancake/getCakeApys.js
+++ b/src/api/stats/pancake/getCakeApys.js
@@ -6,7 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
 const pools = require('../../../data/cakePools.json');
 const { compound } = require('../../../utils/compound');
-const { HOURLY_HPY } = require('../../../../constants');
+const { HOURLY_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getCakeApys = async () => {
   let apys = {};
@@ -42,7 +43,7 @@ const getPoolApy = async pool => {
 const getYearlyRewardsInUsd = async (smartChefAddr, oracle, oracleId, decimals) => {
   const smartChefContract = new web3.eth.Contract(SmartChef, smartChefAddr);
 
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID);
   const bonusEndBlock = await smartChefContract.methods.bonusEndBlock().call();
   const isPoolRunning = currentBlock <= bonusEndBlock;
 

--- a/src/api/stats/pancake/getCakeLpApys.js
+++ b/src/api/stats/pancake/getCakeLpApys.js
@@ -3,10 +3,11 @@ const { bscWeb3: web3 } = require('../../../utils/web3');
 
 const MasterChef = require('../../../abis/MasterChef.json');
 const fetchPrice = require('../../../utils/fetchPrice');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 const pools = require('../../../data/cakeLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
 
 const getCakeLpApys = async () => {
   let apys = {};
@@ -35,7 +36,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/pancake/getCakePoolApy.js
+++ b/src/api/stats/pancake/getCakePoolApy.js
@@ -5,7 +5,8 @@ const MasterChef = require('../../../abis/MasterChef.json');
 const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
 const { compound } = require('../../../utils/compound');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getCakePoolApy = async () => {
   const masterChef = '0x73feaa1eE314F8c655E354234017bE2193C9E24E';
@@ -25,7 +26,7 @@ const getCakePoolApy = async () => {
 };
 
 const getYearlyRewardsInUsd = async (masterChefAddr, oracle, oracleId) => {
-  const fromBlock = await web3.eth.getBlockNumber();
+  const fromBlock = await getBlockNumber(BSC_CHAIN_ID);
   const toBlock = fromBlock + 1;
   const masterChefContract = new web3.eth.Contract(MasterChef, masterChefAddr);
 

--- a/src/api/stats/pumpy/getPumpyLpApys.js
+++ b/src/api/stats/pumpy/getPumpyLpApys.js
@@ -6,6 +6,8 @@ const Strat = require('../../../abis/AutoStratX.json');
 const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/pumpyLpPools.json');
 const { compound } = require('../../../utils/compound');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0x29142471a5c33a2a4cD7C8f18Ce881F699b0c681';
 const oracleId = 'PMP';
@@ -49,7 +51,7 @@ const getTotalLpStakedInUsd = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/ramen/getRamenLpApys.js
+++ b/src/api/stats/ramen/getRamenLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/ramenLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getRamenLpApys = async () => {
   let apys = {};
@@ -33,7 +35,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/snowball/getSnobLpApys.js
+++ b/src/api/stats/snowball/getSnobLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/snobLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { AVAX_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0xB12531a2d758c7a8BF09f44FC88E646E1BF9D375';
 const oracleId = 'SNOB';
@@ -39,7 +41,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(AVAX_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/sponge/getSpongeLpApys.js
+++ b/src/api/stats/sponge/getSpongeLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/spongeLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getSpongeLpApys = async () => {
   let apys = {};
@@ -33,7 +35,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/sponge/getSpongePoolApy.js
+++ b/src/api/stats/sponge/getSpongePoolApy.js
@@ -5,6 +5,8 @@ const MasterChef = require('../../../abis/MasterChef.json');
 const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
 const { compound } = require('../../../utils/compound');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getSoakPoolApy = async () => {
   const masterChef = '0x303961805A22d76Bac6B2dE0c33FEB746d82544B';
@@ -24,7 +26,7 @@ const getSoakPoolApy = async () => {
 };
 
 const getYearlyRewardsInUsd = async (masterChefAddr, oracle, oracleId) => {
-  const fromBlock = await web3.eth.getBlockNumber();
+  const fromBlock = await getBlockNumber(BSC_CHAIN_ID);
   const toBlock = fromBlock + 1;
   const masterChefContract = new web3.eth.Contract(MasterChef, masterChefAddr);
 

--- a/src/api/stats/swipe/getSwipeLpApys.js
+++ b/src/api/stats/swipe/getSwipeLpApys.js
@@ -6,6 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/swipeLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const masterchef = '0xe6421c0cc2d647be51c11ae952927ab38dd6f753';
 const oracleId = 'SXP';
@@ -38,7 +40,7 @@ const getPoolApy = async (masterchef, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (masterchef, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
 
   const multiplier = new BigNumber(

--- a/src/api/stats/thugs/getBaseDrugsApy.js
+++ b/src/api/stats/thugs/getBaseDrugsApy.js
@@ -5,6 +5,8 @@ const OriginalGangster = require('../../../abis/OriginalGangster.json');
 const ERC20 = require('../../../abis/ERC20.json');
 const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
+const { BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const ORIGINAL_GANGSTER = '0x03edb31BeCc296d45670790c947150DAfEC2E238';
 const DRUGS_V2 = '0x339550404Ca4d831D12B1b2e4768869997390010';
@@ -25,7 +27,7 @@ const getBaseDrugsApy = async () => {
 };
 
 const getYearlyRewardsInUsd = async (originalGangsterAddr, oracle, oracleId) => {
-  const fromBlock = await web3.eth.getBlockNumber();
+  const fromBlock = await getBlockNumber(BSC_CHAIN_ID);
   const toBlock = fromBlock + 1;
   const originalGangsterContract = new web3.eth.Contract(OriginalGangster, originalGangsterAddr);
 

--- a/src/api/stats/thugs/getDrugsApys.js
+++ b/src/api/stats/thugs/getDrugsApys.js
@@ -7,7 +7,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
 const pools = require('../../../data/drugsPools.json');
 const { compound } = require('../../../utils/compound');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getDrugsApys = async () => {
   const apys = {};
@@ -35,7 +36,7 @@ const getDrugsApys = async () => {
 const getYearlyRewardsInUsd = async (smartGangsterAddr, oracle, oracleId, decimals) => {
   const smartGangsterContract = new web3.eth.Contract(SmartGangster, smartGangsterAddr);
 
-  const currentBlock = await web3.eth.getBlockNumber();
+  const currentBlock = await getBlockNumber(BSC_CHAIN_ID);
   const bonusEndBlock = await smartGangsterContract.methods.bonusEndBlock().call();
   const isPoolRunning = currentBlock <= bonusEndBlock;
 

--- a/src/api/stats/thugs/getThugsLpApys.js
+++ b/src/api/stats/thugs/getThugsLpApys.js
@@ -6,7 +6,8 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/thugsLpPools.json');
 const { compound } = require('../../../utils/compound');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
-const { BASE_HPY } = require('../../../../constants');
+const { BASE_HPY, BSC_CHAIN_ID } = require('../../../../constants');
+const getBlockNumber = require('../../../utils/getBlockNumber');
 
 const getThugsLpApys = async () => {
   let apys = {};
@@ -34,7 +35,7 @@ const getPoolApy = async (gangster, pool) => {
 };
 
 const getYearlyRewardsInUsd = async (gangster, pool) => {
-  const blockNum = await web3.eth.getBlockNumber();
+  const blockNum = await getBlockNumber(BSC_CHAIN_ID);
   const gangsterContract = new web3.eth.Contract(OriginalGangster, gangster);
 
   const multiplier = new BigNumber(

--- a/src/utils/getBlockNumber.js
+++ b/src/utils/getBlockNumber.js
@@ -1,0 +1,21 @@
+const { web3Factory } = require('./web3');
+
+const fastestChainBlockTimeInMilliseconds = 3000
+
+let cache = {};
+const getBlockNumber = async (chainId) => {
+  const cacheKey = Math.floor(Date.now() / fastestChainBlockTimeInMilliseconds)
+
+  if (cache[chainId]?.hasOwnProperty(cacheKey)) {
+    return cache[chainId][cacheKey];
+  }
+
+  const web3 = web3Factory(chainId);
+  const blockNumberPromise = web3.eth.getBlockNumber();
+  cache[chainId] = {
+    [cacheKey]: blockNumberPromise
+  }
+  return blockNumberPromise;
+};
+
+module.exports = getBlockNumber;

--- a/src/utils/getDailyEarnings.js
+++ b/src/utils/getDailyEarnings.js
@@ -1,7 +1,7 @@
-const { bscWeb3: web3 } = require('./web3');
 const { BigNumber, ethers } = require('ethers');
-const { BSC_RPC } = require('../../constants');
+const { BSC_RPC, BSC_CHAIN_ID } = require('../../constants');
 const ERC20 = require('../abis/ERC20.json');
+const getBlockNumber = require('../utils/getBlockNumber');
 
 const getDailyEarnings = async () => {
   const provider = new ethers.providers.JsonRpcProvider(BSC_RPC);
@@ -10,7 +10,7 @@ const getDailyEarnings = async () => {
 
   let totalEarnings = BigNumber.from(0);
   let difference = 20 * 60 * 24;
-  const endBlock = await web3.eth.getBlockNumber();
+  const endBlock = await getBlockNumber(BSC_CHAIN_ID);
   const startBlock = endBlock - difference;
   let currentBlock = startBlock;
   let result = BigNumber.from(0);
@@ -21,9 +21,9 @@ const getDailyEarnings = async () => {
       let data = await contract.queryFilter(filterTo, currentBlock, currentBlock+5000);
       for (var i = 0; i < data.length; i++ ){
         let hexAmount = data[i]["args"][2];
-        
+
         let amount = BigNumber.from(hexAmount);
-        
+
         totalEarnings = totalEarnings.add(amount);
       }
       currentBlock += 5000;
@@ -31,8 +31,8 @@ const getDailyEarnings = async () => {
 
     console.log("> calculated daily earnings");
     // divide twice to avoid overflow error, 1e16 so we can have 2 decimal places in response
-    let result = (totalEarnings.div(1e9)).div(1e7); 
-    
+    let result = (totalEarnings.div(1e9)).div(1e7);
+
     return {
       daily: result.toNumber() / 100,
       startBlock: startBlock,
@@ -46,7 +46,7 @@ const getDailyEarnings = async () => {
       endBlock: endBlock,
     };
   }
-  
+
 };
-  
+
 module.exports = { getDailyEarnings };

--- a/src/utils/getRewardsReceived.js
+++ b/src/utils/getRewardsReceived.js
@@ -12,8 +12,8 @@ const FIRST_REWARD_BLOCK = 1457038;
 
 // pre-calculated rewards for specific block to get them fetched faster
 // can be updated with the values from the "getRewardsReceived" log below
-const CACHED_REWARDS = '11913596032480523065355'
-const CACHED_REWARD_BLOCK = 5996613
+const CACHED_REWARDS = '12666620458793696118763'
+const CACHED_REWARD_BLOCK = 6114579
 
 const REWARD_POOL = '0x453D4Ba9a2D594314DF88564248497F7D74d6b2C';
 const WBNB = '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c';

--- a/src/utils/getRewardsReceived.js
+++ b/src/utils/getRewardsReceived.js
@@ -1,6 +1,8 @@
 const { bscWeb3: web3 } = require('./web3');
 const BigNumber = require('bignumber.js');
 const { sleep } = require('./time');
+const { BSC_CHAIN_ID } = require('../../constants');
+const getBlockNumber = require('./getBlockNumber');
 
 const { getTopicFromSignature, getTopicFromAddress, getValueFromData } = require('./topicHelpers');
 
@@ -21,13 +23,13 @@ const getRewardsReceived = async () => {
 
   const transferTopic = getTopicFromSignature('Transfer(address,address,uint256)');
   const toTopic = getTopicFromAddress(REWARD_POOL);
-  
-  const lastBlock = await web3.eth.getBlockNumber();
+
+  const lastBlock = await getBlockNumber(BSC_CHAIN_ID);
   let fromBlock = CACHED_REWARD_BLOCK;
 
   while (fromBlock < lastBlock) {
     let toBlock = fromBlock + RPC_QUERY_LIMIT;
-    if (toBlock > lastBlock) { 
+    if (toBlock > lastBlock) {
       toBlock = lastBlock;
     }
 
@@ -42,7 +44,7 @@ const getRewardsReceived = async () => {
       const value = getValueFromData(logs[i].data);
       result = result.plus(value);
     }
-   
+
     await sleep(RPC_QUERY_INTERVAL);
 
     fromBlock = toBlock;


### PR DESCRIPTION
Part of the #103

This shaves out 168 requests to get current block number on startup and every APY recalculation. Also added more BSC RPC endpoints and updated rewards cache.

New get current block logic: https://github.com/beefyfinance/beefy-api/pull/119/files#diff-b0583588bba3a9df9cc532425ae60989bb13fc1e5a02ef91ff33563aa3cac9cb