### PR TITLE
Fix sushi apys

### DIFF
--- a/src/api/stats/matic/getSushiLpApys.js
+++ b/src/api/stats/matic/getSushiLpApys.js
@@ -7,18 +7,10 @@ const SushiComplexRewarderTime = require('../../../abis/matic/SushiComplexReward
 const ERC20 = require('../../../abis/ERC20.json');
 const fetchPrice = require('../../../utils/fetchPrice');
 const pools = require('../../../data/matic/sushiLpPools.json');
+const { BASE_HPY, POLYGON_CHAIN_ID } = require('../../../constants');
+const { getTradingFeeAprSushi: getTradingFeeApr } = require('../../../utils/getTradingFeeApr');
 const getFarmWithTradingFeesApy = require('../../../utils/getFarmWithTradingFeesApy');
-const { POLYGON_CHAIN_ID } = require('../../../constants');
-const { BASE_HPY } = require('../../../constants');
-
-const { exchange_matic, minichefv2_matic, blockClient_matic } = require('../../../apollo/client');
-const { startOfMinute, subDays } = require('date-fns');
-const {
-  blockQuery,
-  pairSubsetQuery,
-  pairTimeTravelQuery,
-  miniChefPoolQuery,
-} = require('../../../apollo/queries');
+const { sushiClient } = require('../../../apollo/client');
 
 const minichef = '0x0769fd68dFb93167989C6f7254cd0D766Fb2841F';
 const oracleId = 'SUSHI';
@@ -26,6 +18,7 @@ const oracle = 'tokens';
 const DECIMALS = '1e18';
 const secondsPerBlock = 1;
 const secondsPerYear = 31536000;
+const liquidityProviderFee = 0.0025;
 
 // matic
 const complexRewarderTime = '0xa3378Ca78633B3b9b2255EAa26748770211163AE';
@@ -33,12 +26,13 @@ const oracleIdMatic = 'WMATIC';
 
 const getSushiLpApys = async () => {
   let apys = {};
-  const tradingAprs = await getTradingFeeAprSushi();
+  const pairAddresses = pools.map(pool => pool.address);
+  const tradingAprs = await getTradingFeeApr(sushiClient, pairAddresses, liquidityProviderFee);
   const farmApys = await getFarmApys(pools);
 
   pools.forEach((pool, i) => {
     const simpleApy = farmApys[i];
-    const tradingApr = new BigNumber(tradingAprs[pool.poolId]);
+    const tradingApr = tradingAprs[pool.address.toLowerCase()] ?? new BigNumber(0);
     const apy = getFarmWithTradingFeesApy(simpleApy, tradingApr, BASE_HPY, 1, 0.955);
     apys = { ...apys, ...{ [pool.name]: apy } };
   });
@@ -111,78 +105,6 @@ const getPoolsData = async pools => {
   const allocPoints = res[1].map(v => v.allocPoint['2']);
   const rewardAllocPoints = res[2].map(v => v.allocPoint['2']);
   return { balances, allocPoints, rewardAllocPoints };
-};
-
-const getTradingFeeAprSushi = async () => {
-  // adapted from: https://github.com/sushiswap/sushiswap-interface/blob/bb6969dac2b06b2fcaed6d10493a4ccd3595e08f/src/hooks/minichefv2/useFarms.ts#L27
-  const minichefQueryResult = await minichefv2_matic.query({
-    query: miniChefPoolQuery,
-  });
-
-  const miniChefPools = minichefQueryResult.data.pools;
-  const pairAddresses = miniChefPools
-    .map(pool => {
-      return pool.pair;
-    })
-    .sort();
-  const pairsQuery = await exchange_matic.query({
-    query: pairSubsetQuery,
-    variables: { pairAddresses },
-  });
-  const oneDayBlock = await getOneDayBlock();
-  const pairs24AgoQuery = await Promise.all(
-    pairAddresses.map(address => {
-      return exchange_matic.query({
-        query: pairTimeTravelQuery,
-        variables: { id: address, block: oneDayBlock },
-      });
-    })
-  );
-  const pairs24Ago = pairs24AgoQuery.map(query => {
-    return {
-      ...query?.data?.pair,
-    };
-  });
-
-  const pairs = pairsQuery?.data.pairs;
-
-  const farms = miniChefPools.filter(pool => pairs.find(pair => pair.id === pool.pair));
-
-  let feeAprs = {};
-
-  for (const pool of farms) {
-    const pair = pairs.find(pair => pair.id === pool.pair);
-    const pair24Ago = pairs24Ago.find(pair => pair.id === pool.pair);
-    let feeApr = 0;
-    if (pair && pair24Ago) {
-      const oneDayVolume = pair.volumeUSD - pair24Ago.volumeUSD;
-      const oneYearApr = (oneDayVolume * 0.003 * 365) / pair.reserveUSD;
-      feeApr = { [pool.id]: oneYearApr };
-    }
-    feeAprs = { ...feeAprs, ...feeApr };
-  }
-
-  return feeAprs;
-};
-
-const getOneDayBlock = async () => {
-  const date = startOfMinute(subDays(Date.now(), 1));
-  const start = Math.floor(Number(date) / 1000);
-  const end = Math.floor(Number(date) / 1000) + 600;
-
-  const blocksData = await blockClient_matic.query({
-    query: blockQuery,
-    variables: {
-      start,
-      end,
-    },
-    context: {
-      clientName: 'blocklytics',
-    },
-    fetchPolicy: 'network-only',
-  });
-
-  return { number: Number(blocksData?.data?.blocks[0].number) };
 };
 
 module.exports = getSushiLpApys;

--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -3,30 +3,13 @@ const fetch = require('node-fetch');
 const createHttpLink = require('apollo-link-http').createHttpLink;
 const InMemoryCache = require('apollo-cache-inmemory').InMemoryCache;
 
-const exchange_matic = new ApolloClient({
+const sushiClient = new ApolloClient({
   link: createHttpLink({
     uri: 'https://api.thegraph.com/subgraphs/name/sushiswap/matic-exchange',
     fetch,
   }),
   cache: new InMemoryCache(),
   shouldBatch: true,
-});
-
-const minichefv2_matic = new ApolloClient({
-  link: createHttpLink({
-    uri: 'https://api.thegraph.com/subgraphs/name/sushiswap/matic-minichef',
-    fetch,
-  }),
-  cache: new InMemoryCache(),
-  shouldBatch: true,
-});
-
-const blockClient_matic = new ApolloClient({
-  link: createHttpLink({
-    uri: 'https://api.thegraph.com/subgraphs/name/matthewlilley/polygon-blocks',
-    fetch,
-  }),
-  cache: new InMemoryCache(),
 });
 
 const comethClient = new ApolloClient({
@@ -54,9 +37,7 @@ const polyzapClient = new ApolloClient({
 });
 
 module.exports = {
-  exchange_matic,
-  minichefv2_matic,
-  blockClient_matic,
+  sushiClient,
   comethClient,
   quickClient,
   polyzapClient,

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -1,119 +1,5 @@
 const gql = require('graphql-tag');
 
-const miniChefPoolQuery = gql`
-  query poolsQuery(
-    $first: Int! = 1000
-    $skip: Int! = 0
-    $orderBy: String! = "timestamp"
-    $orderDirection: String! = "desc"
-  ) {
-    pools(first: $first, skip: $skip, orderBy: $orderBy, orderDirection: $orderDirection) {
-      id
-      pair
-      rewarder {
-        id
-        rewardToken
-        rewardPerSecond
-      }
-      allocPoint
-      lastRewardTime
-      accSushiPerShare
-      slpBalance
-      userCount
-      miniChef {
-        id
-        sushiPerSecond
-        totalAllocPoint
-      }
-    }
-  }
-`;
-
-const blockFieldsQuery = gql`
-  fragment blockFields on Block {
-    id
-    number
-    timestamp
-  }
-`;
-
-const blockQuery = gql`
-  query blockQuery($start: Int!, $end: Int!) {
-    blocks(
-      first: 1
-      orderBy: timestamp
-      orderDirection: asc
-      where: { timestamp_gt: $start, timestamp_lt: $end }
-    ) {
-      ...blockFields
-    }
-  }
-  ${blockFieldsQuery}
-`;
-
-const pairTokenFieldsQuery = gql`
-  fragment pairTokenFields on Token {
-    id
-    name
-    symbol
-    totalSupply
-    derivedETH
-  }
-`;
-
-const pairFieldsQuery = gql`
-  fragment pairFields on Pair {
-    id
-    reserveUSD
-    reserveETH
-    volumeUSD
-    untrackedVolumeUSD
-    trackedReserveETH
-    token0 {
-      ...pairTokenFields
-    }
-    token1 {
-      ...pairTokenFields
-    }
-    reserve0
-    reserve1
-    token0Price
-    token1Price
-    totalSupply
-    txCount
-    timestamp
-  }
-  ${pairTokenFieldsQuery}
-`;
-
-const pairSubsetQuery = gql`
-  query pairSubsetQuery(
-    $first: Int! = 1000
-    $pairAddresses: [Bytes]!
-    $orderBy: String! = "trackedReserveETH"
-    $orderDirection: String! = "desc"
-  ) {
-    pairs(
-      first: $first
-      orderBy: $orderBy
-      orderDirection: $orderDirection
-      where: { id_in: $pairAddresses }
-    ) {
-      ...pairFields
-    }
-  }
-  ${pairFieldsQuery}
-`;
-
-const pairTimeTravelQuery = gql`
-  query pairTimeTravelQuery($id: String!, $block: Block_height!) {
-    pair(id: $id, block: $block) {
-      ...pairFields
-    }
-  }
-  ${pairFieldsQuery}
-`;
-
 const pairDayDataQuery = (pairs, startTimestamp) => {
   let pairsString = `[`;
   pairs.map(pair => {
@@ -137,10 +23,32 @@ const pairDayDataQuery = (pairs, startTimestamp) => {
   return gql(queryString);
 };
 
+const pairDayDataSushiQuery = (pairs, startTimestamp) => {
+  let pairsString = `[`;
+  pairs.map(pair => {
+    return (pairsString += `"${pair}"`);
+  });
+  pairsString += ']';
+  const queryString = `
+    query days {
+      pairs(where: { id_in: ${pairsString}}) {
+        dayData(first: 1000, orderBy: date, orderDirection: asc, where: { date_gt: ${startTimestamp} }) {
+          id
+          pair
+          date
+          volumeToken0
+          volumeToken1
+          volumeUSD
+          totalSupply
+          reserveUSD
+        }
+      }
+    } 
+`;
+  return gql(queryString);
+};
+
 module.exports = {
-  miniChefPoolQuery,
-  blockQuery,
-  pairTimeTravelQuery,
-  pairSubsetQuery,
   pairDayDataQuery,
+  pairDayDataSushiQuery,
 };

--- a/src/utils/getTradingFeeApr.js
+++ b/src/utils/getTradingFeeApr.js
@@ -1,5 +1,5 @@
 const { startOfMinute, subDays } = require('date-fns');
-const { pairDayDataQuery } = require('../apollo/queries');
+const { pairDayDataQuery, pairDayDataSushiQuery } = require('../apollo/queries');
 const BigNumber = require('bignumber.js');
 
 const getTradingFeeApr = async (client, pairAddresses, liquidityProviderFee) => {
@@ -25,6 +25,30 @@ const getTradingFeeApr = async (client, pairAddresses, liquidityProviderFee) => 
   return pairAddressToAprMap;
 };
 
+const getTradingFeeAprSushi = async (client, pairAddresses, liquidityProviderFee) => {
+  const date = startOfMinute(subDays(Date.now(), 1));
+  const start = Math.floor(Number(date) / 1000);
+
+  let queryResponse = await client.query({
+    query: pairDayDataSushiQuery(pairAddresses, start),
+  });
+
+  const pairDayDatas = queryResponse.data.pairs.map(pair => pair.dayData[0]);
+
+  const pairAddressToAprMap = {};
+  for (const pairDayData of pairDayDatas) {
+    const { id } = pairDayData;
+    const pairAddress = id.split('-')[0].toLowerCase();
+    pairAddressToAprMap[pairAddress] = new BigNumber(pairDayData.volumeUSD)
+      .times(liquidityProviderFee)
+      .times(365)
+      .dividedBy(pairDayData.reserveUSD);
+  }
+
+  return pairAddressToAprMap;
+};
+
 module.exports = {
   getTradingFeeApr,
+  getTradingFeeAprSushi,
 };


### PR DESCRIPTION
Unfortunately I don't have the root cause of why the APYs weren't adding up on refresh. Basically the issue seen is on periodic refresh of apys by the api, the trading aprs would show up as negative for sushi vaults. This code path was different than everywhere else (quick, cometh, polyzap). The code path was adapted to be very similar, but sushi requires a different query so it's slightly different. This was tested by leaving the api running indef and setting a breakpoint on the getSushiLPApys call, and making sure the subsequent trading apr is in the ballpark range