### PR TITLE
Use previous full day data for trading APR

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -1,6 +1,6 @@
 const gql = require('graphql-tag');
 
-const pairDayDataQuery = (pairs, startTimestamp) => {
+const pairDayDataQuery = (pairs, startTimestamp, endTimestamp) => {
   let pairsString = `[`;
   pairs.map(pair => {
     return (pairsString += `"${pair}"`);
@@ -8,7 +8,7 @@ const pairDayDataQuery = (pairs, startTimestamp) => {
   pairsString += ']';
   const queryString = `
     query days {
-      pairDayDatas(first: 1000, orderBy: date, orderDirection: asc, where: { pairAddress_in: ${pairsString}, date_gt: ${startTimestamp} }) {
+      pairDayDatas(first: 1000, orderBy: date, orderDirection: asc, where: { pairAddress_in: ${pairsString}, date_gt: ${startTimestamp}, date_lt: ${endTimestamp} }) {
         id
         pairAddress 
         date
@@ -23,7 +23,7 @@ const pairDayDataQuery = (pairs, startTimestamp) => {
   return gql(queryString);
 };
 
-const pairDayDataSushiQuery = (pairs, startTimestamp) => {
+const pairDayDataSushiQuery = (pairs, startTimestamp, endTimestamp) => {
   let pairsString = `[`;
   pairs.map(pair => {
     return (pairsString += `"${pair}"`);
@@ -32,7 +32,7 @@ const pairDayDataSushiQuery = (pairs, startTimestamp) => {
   const queryString = `
     query days {
       pairs(where: { id_in: ${pairsString}}) {
-        dayData(first: 1000, orderBy: date, orderDirection: asc, where: { date_gt: ${startTimestamp} }) {
+        dayData(first: 1000, orderBy: date, orderDirection: asc, where: { date_gt: ${startTimestamp}, date_lt: ${endTimestamp} }) {
           id
           pair
           date

--- a/src/utils/getTradingFeeApr.js
+++ b/src/utils/getTradingFeeApr.js
@@ -3,13 +3,12 @@ const { pairDayDataQuery, pairDayDataSushiQuery } = require('../apollo/queries')
 const BigNumber = require('bignumber.js');
 
 const getTradingFeeApr = async (client, pairAddresses, liquidityProviderFee) => {
-  const date = startOfMinute(subDays(Date.now(), 1));
-  const start = Math.floor(Number(date) / 1000);
+  const [start, end] = getStartAndEndDate();
 
   let {
     data: { pairDayDatas },
   } = await client.query({
-    query: pairDayDataQuery(pairAddresses, start),
+    query: pairDayDataQuery(addressesToLowercase(pairAddresses), start, end),
   });
 
   const pairAddressToAprMap = {};
@@ -26,11 +25,10 @@ const getTradingFeeApr = async (client, pairAddresses, liquidityProviderFee) => 
 };
 
 const getTradingFeeAprSushi = async (client, pairAddresses, liquidityProviderFee) => {
-  const date = startOfMinute(subDays(Date.now(), 1));
-  const start = Math.floor(Number(date) / 1000);
+  const [start, end] = getStartAndEndDate();
 
   let queryResponse = await client.query({
-    query: pairDayDataSushiQuery(pairAddresses, start),
+    query: pairDayDataSushiQuery(addressesToLowercase(pairAddresses), start, end),
   });
 
   const pairDayDatas = queryResponse.data.pairs.map(pair => pair.dayData[0]);
@@ -47,6 +45,19 @@ const getTradingFeeAprSushi = async (client, pairAddresses, liquidityProviderFee
 
   return pairAddressToAprMap;
 };
+
+const getUTCSeconds = (date /*: Date*/) => Math.floor(Number(date) / 1000);
+
+const getStartAndEndDate = () => {
+  // Use data between (now - 2) days and (now - 1) day, since current day data is still being produced
+  const endDate = startOfMinute(subDays(Date.now(), 1));
+  const startDate = startOfMinute(subDays(Date.now(), 2));
+  const [start, end] = [startDate, endDate].map(getUTCSeconds);
+  return [start, end];
+};
+
+const addressesToLowercase = (pairAddresses /*: string[]*/) =>
+  pairAddresses.map(address => address.toLowerCase());
 
 module.exports = {
   getTradingFeeApr,


### PR DESCRIPTION
The latest DayPairData isn't complete, as its still being written to for that day, as pointed out by @roman-monk. This cause underestimation in volume. As a result, we use the data for the soonest day we have full daily data for, which is the entry between (now-2) days and (now-1) days