### PR TITLE
[WIP] Get LP token info from Want token

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "apollo-link-http": "^1.5.17",
     "axios": "^0.20.0",
     "bignumber.js": "^9.0.1",
+    "blockchain-addressbook": "^0.1.15",
     "date-fns": "^2.21.3",
     "eth-multicall": "^1.3.13",
     "ethers": "^5.0.26",

--- a/src/api/stats/getAmmPrices.js
+++ b/src/api/stats/getAmmPrices.js
@@ -80,6 +80,7 @@ const jetswapPools = require('../../data/jetswapLpPools.json');
 const dumplingPools = require('../../data/degens/dumplingLpPools.json');
 const grandPools = require('../../data/grandLpPools.json');
 const ironMaticPools = require('../../data/matic/ironLpPools.json');
+const fetchLPTokensFromPairContract = require('../../utils/fetchLPTokensFromPairContract');
 
 const INIT_DELAY = 0 * 60 * 1000;
 const REFRESH_INTERVAL = 5 * 60 * 1000;
@@ -184,6 +185,9 @@ const updateAmmPrices = async () => {
   console.log('> updating amm prices');
   isProcessing = true;
   try {
+    for (const pool of pools) {
+      await fetchLPTokensFromPairContract(pool);
+    }
     let { poolPrices, tokenPrices } = await fetchAmmPrices(pools, knownPrices);
     const nonAmmPrices = await getNonAmmPrices(tokenPrices);
     tokenPricesCache = tokenPrices;

--- a/src/utils/fetchLPTokensFromPairContract.js
+++ b/src/utils/fetchLPTokensFromPairContract.js
@@ -1,0 +1,46 @@
+const { ethers } = require('ethers');
+const { MULTICHAIN_RPC } = require('../constants');
+const LPPair = require('../abis/LPPair.json');
+const { addressBook } = require('blockchain-addressbook');
+
+const fetchLPTokensFromPairContract = pool => {
+  const { chainId } = pool;
+  // Setup multichain
+  const provider = new ethers.providers.JsonRpcProvider(MULTICHAIN_RPC[chain]);
+  const lpContract = new ethers.Contract(pool.address, LPPair, provider);
+  const token0Address = lpContract.token0();
+  const token1Address = lpContract.token1();
+
+  // lookup in addressbook
+  if (chainId && chainId in chainIdToAddressBookMap) {
+    const chainAddressBook = chainIdToAddressBookMap[chainId];
+    const { tokenAddressMap } = chainAddressBook;
+
+    const setTokenData = (tokenAddress, idx) => {
+      // lookup in tokenAddressMap
+      // caution, may need to checksum this address if the address we get from the pair contract is not checksummed
+      if (tokenAddress in tokenAddressMap) {
+        const token = tokenAddressMap[tokenAddress];
+        // Add to pool data, or mutate existing data
+        const existingData = pool['lp' + idx];
+        let newData = existingData ? existingData : {};
+        newData.address = token.address;
+        newData.oracleId = token.symbol;
+        newData.decimals = '1e' + token.decimals.toString();
+      }
+    };
+
+    // update token0 and token1 info
+    [token0Address, token1Address].forEach((address, idx) => setTokenData(address, idx));
+  }
+};
+
+const chainIdToAddressBookMap = {
+  56: addressBook.bsc,
+  // 128: undefined,
+  137: addressBook.polygon,
+  43114: addressBook.avax,
+  250: addressBook.fantom,
+};
+
+module.exports = fetchLPTokensFromPairContract;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,6 +1413,11 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
+blockchain-addressbook@^0.1.15:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/blockchain-addressbook/-/blockchain-addressbook-0.1.15.tgz#dc2c714fd8214a25954550ed9f416a5648a288aa"
+  integrity sha512-j8MDH4nOi6wS4NfeWLU7YE254SgyA8tZgM/HZp1tsFwbUUnjpvlfANYXX4+6qC8VDx8mj1ZdbesCGBhOdkgXVw==
+
 bluebird@^3.5.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"


### PR DESCRIPTION
We currently have to put the lp0 info and lp1 info for every pool in our json file. We could deduce this info instead of hardcoding it here, via the paircontract, and then perform a lookup in the addressbook. This PR demonstrates that concept. It is a WIP since it needs to run prior to any of the pool jsons being used, which is not the case, as they are sometimes directly imported in the getAPY calculation. It also needs some multicall optimization. Nevertheless, this concept can be reused to automate the pancake vault deployments, as @wivern-co-uk would like to do