### PR TITLE
Add etag support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "husky": "^6.0.0",
     "koa": "^2.13.0",
     "koa-bodyparser": "^4.3.0",
+    "koa-conditional-get": "^3.0.0",
+    "koa-etag": "^4.0.0",
     "koa-helmet": "^5.2.0",
     "koa-router": "^9.4.0",
     "lint-staged": "^11.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -4,15 +4,20 @@ const Koa = require('koa');
 const helmet = require('koa-helmet');
 const body = require('koa-bodyparser');
 const cors = require('@koa/cors');
+const conditional = require('koa-conditional-get');
+const etag = require('koa-etag');
 
 const rt = require('./middleware/rt');
 const powered = require('./middleware/powered');
 const router = require('./router');
 
 const app = new Koa();
+
+app.use(rt);
+app.use(conditional());
+app.use(etag());
 app.use(helmet());
 app.use(cors({ origin: '*' }));
-app.use(rt);
 app.use(powered);
 app.use(body());
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,7 +2479,7 @@ esutils@^2.0.3:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-etag@~1.8.1:
+etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
@@ -3837,6 +3837,11 @@ koa-compose@^4.1.0:
   resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
   integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
 
+koa-conditional-get@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/koa-conditional-get/-/koa-conditional-get-3.0.0.tgz#552cb64a217dfb907e90b7c34f42009e441c4b8e"
+  integrity sha512-VKyPS7SuNH26TjTV2IRz+oh0HV/jc2lYAo51PTQTkj0XFn8ebNZW9riczmrW7ZVBFSnls1Z88DPUYKnvVymruA==
+
 koa-convert@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/koa-convert/-/koa-convert-1.2.0.tgz#da40875df49de0539098d1700b50820cebcd21d0"
@@ -3844,6 +3849,13 @@ koa-convert@^1.2.0:
   dependencies:
     co "^4.6.0"
     koa-compose "^3.0.0"
+
+koa-etag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/koa-etag/-/koa-etag-4.0.0.tgz#2c2bb7ae69ca1ac6ced09ba28dcb78523c810414"
+  integrity sha512-1cSdezCkBWlyuB9l6c/IFoe1ANCDdPBxkDkRiaIup40xpUub6U/wwRXoKBZw/O5BifX9OlqAjYnDyzM6+l+TAg==
+  dependencies:
+    etag "^1.8.1"
 
 koa-helmet@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
Uses `koa-conditional-get` and `koa-etag` to add etag support to the API.

Will set an ETag: header on 2XX responses containing a hash of the content returned.

In follow up requests, the browser will send a If-None-Match: header containing the last ETag received. 

If the tags match, the API will respond with a 304 Not Modified and only send headers to the browser, dropping the body. 

This should speed up responses where the data hasn't changed.