### PR TITLE
Feat/apy endpoint migration

### DIFF
--- a/src/api/stats/fantom/getSpookyLpApys.js
+++ b/src/api/stats/fantom/getSpookyLpApys.js
@@ -69,7 +69,7 @@ const getSpookyLpApys = async () => {
     // Create reference for breakdown /apy
     const componentValues = {
       [pool.name]: {
-        simpleApy: simpleApy.toNumber(),
+        vaultApr: simpleApy.toNumber(),
         compoundingsPerYear: BASE_HPY,
         beefyPerformanceFee: beefyPerformanceFee,
         vaultApy: vaultApy,

--- a/src/api/stats/fantom/index.js
+++ b/src/api/stats/fantom/index.js
@@ -14,6 +14,7 @@ const getApys = [
 
 const getFantomApys = async () => {
   let apys = {};
+  let apyBreakdowns = {};
 
   let promises = [];
   getApys.forEach(getApy => promises.push(getApy()));
@@ -24,10 +25,26 @@ const getFantomApys = async () => {
       console.warn('getFantomApys error', result.reason);
       continue;
     }
-    apys = { ...apys, ...result.value };
+
+    // Set default APY values
+    let mappedApyValues = result.value;
+    let mappedApyBreakdownValues = result.value;
+
+    let hasApyBreakdowns = 'apyBreakdowns' in result.value;
+    if (hasApyBreakdowns) {
+      mappedApyValues = result.value.apys;
+      mappedApyBreakdownValues = result.value.apyBreakdowns;
+    }
+
+    apys = { ...apys, ...mappedApyValues };
+
+    apyBreakdowns = { ...apyBreakdowns, mappedApyBreakdownValues };
   }
 
-  return apys;
+  return {
+    apys,
+    apyBreakdowns,
+  };
 };
 
 module.exports = { getFantomApys };

--- a/src/api/stats/fantom/index.js
+++ b/src/api/stats/fantom/index.js
@@ -28,8 +28,17 @@ const getFantomApys = async () => {
 
     // Set default APY values
     let mappedApyValues = result.value;
-    let mappedApyBreakdownValues = result.value;
+    let mappedApyBreakdownValues = {};
 
+    // Loop through key values and move default breakdown format
+    // To require totalApy key
+    for (const [key, value] of Object.entries(result.value)) {
+      mappedApyBreakdownValues[key] = {
+        totalApy: value,
+      };
+    }
+
+    // Break out to apy and breakdowns if possible
     let hasApyBreakdowns = 'apyBreakdowns' in result.value;
     if (hasApyBreakdowns) {
       mappedApyValues = result.value.apys;

--- a/src/api/stats/fantom/index.js
+++ b/src/api/stats/fantom/index.js
@@ -34,11 +34,13 @@ const getFantomApys = async () => {
     if (hasApyBreakdowns) {
       mappedApyValues = result.value.apys;
       mappedApyBreakdownValues = result.value.apyBreakdowns;
+
+      console.log(mappedApyBreakdownValues);
     }
 
     apys = { ...apys, ...mappedApyValues };
 
-    apyBreakdowns = { ...apyBreakdowns, mappedApyBreakdownValues };
+    apyBreakdowns = { ...apyBreakdowns, ...mappedApyBreakdownValues };
   }
 
   return {

--- a/src/api/stats/getApys.js
+++ b/src/api/stats/getApys.js
@@ -40,8 +40,17 @@ const updateApys = async () => {
 
       // Set default APY values
       let mappedApyValues = result.value;
-      let mappedApyBreakdownValues = result.value;
+      let mappedApyBreakdownValues = {};
 
+      // Loop through key values and move default breakdown format
+      // To require totalApy key
+      for (const [key, value] of Object.entries(result.value)) {
+        mappedApyBreakdownValues[key] = {
+          totalApy: value,
+        };
+      }
+
+      // Break out to apy and breakdowns if possible
       let hasApyBreakdowns = 'apyBreakdowns' in result.value;
       if (hasApyBreakdowns) {
         mappedApyValues = result.value.apys;

--- a/src/api/stats/getApys.js
+++ b/src/api/stats/getApys.js
@@ -3,13 +3,14 @@ const getBifiMaxiApy = require('./beefy/getBifiMaxiApy');
 const { getAvaxApys } = require('./avax');
 const { getMaticApys } = require('./matic');
 const { getHecoApys } = require('./heco');
-const { getFantomApys } = require('./fantom');
+const { getFantomApys, getFantomApyBreakdowns } = require('./fantom');
 const { getBSCApys } = require('./bsc');
 
 const INIT_DELAY = 30 * 1000;
 const REFRESH_INTERVAL = 15 * 60 * 1000;
 
 let apys = {};
+let apyBreakdowns = {};
 
 const getApys = () => {
   return apys;
@@ -33,6 +34,21 @@ const updateApys = async () => {
         console.warn('getApys error', result.reason);
         continue;
       }
+
+      // // Set default APY values
+      // let mappedApyValues = result.value
+      // let mappedApyBreakdownValues = result.value
+
+      // let hasApyBreakdowns = "apyBreakdowns" in result.value
+      // if (hasApyBreakdowns) {
+      //   mappedApyValues = result.value.apys
+      //   mappedApyBreakdownValues = result.value.apyBreakdowns
+      // }
+
+      // apys = { ...apys, ...mappedApyValues };
+
+      // apyBreakdowns = { ...apyBreakdowns, mappedApyBreakdownValues };
+
       apys = { ...apys, ...result.value };
     }
 
@@ -46,4 +62,4 @@ const updateApys = async () => {
 
 setTimeout(updateApys, INIT_DELAY);
 
-module.exports = getApys;
+module.exports = { getApys };

--- a/src/api/stats/getApys.js
+++ b/src/api/stats/getApys.js
@@ -3,7 +3,7 @@ const getBifiMaxiApy = require('./beefy/getBifiMaxiApy');
 const { getAvaxApys } = require('./avax');
 const { getMaticApys } = require('./matic');
 const { getHecoApys } = require('./heco');
-const { getFantomApys, getFantomApyBreakdowns } = require('./fantom');
+const { getFantomApys } = require('./fantom');
 const { getBSCApys } = require('./bsc');
 
 const INIT_DELAY = 30 * 1000;
@@ -13,7 +13,10 @@ let apys = {};
 let apyBreakdowns = {};
 
 const getApys = () => {
-  return apys;
+  return {
+    apys,
+    apyBreakdowns,
+  };
 };
 
 const updateApys = async () => {
@@ -35,21 +38,19 @@ const updateApys = async () => {
         continue;
       }
 
-      // // Set default APY values
-      // let mappedApyValues = result.value
-      // let mappedApyBreakdownValues = result.value
+      // Set default APY values
+      let mappedApyValues = result.value;
+      let mappedApyBreakdownValues = result.value;
 
-      // let hasApyBreakdowns = "apyBreakdowns" in result.value
-      // if (hasApyBreakdowns) {
-      //   mappedApyValues = result.value.apys
-      //   mappedApyBreakdownValues = result.value.apyBreakdowns
-      // }
+      let hasApyBreakdowns = 'apyBreakdowns' in result.value;
+      if (hasApyBreakdowns) {
+        mappedApyValues = result.value.apys;
+        mappedApyBreakdownValues = result.value.apyBreakdowns;
+      }
 
-      // apys = { ...apys, ...mappedApyValues };
+      apys = { ...apys, ...mappedApyValues };
 
-      // apyBreakdowns = { ...apyBreakdowns, mappedApyBreakdownValues };
-
-      apys = { ...apys, ...result.value };
+      apyBreakdowns = { ...apyBreakdowns, ...mappedApyBreakdownValues };
     }
 
     console.log('> updated apys');

--- a/src/api/stats/index.js
+++ b/src/api/stats/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getApys = require('./getApys');
+const { getApys } = require('./getApys');
 
 const TIMEOUT = 5 * 60 * 1000;
 
@@ -20,4 +20,20 @@ async function apy(ctx) {
   }
 }
 
-module.exports = { apy };
+async function apyBreakdowns(ctx) {
+  try {
+    ctx.request.socket.setTimeout(TIMEOUT);
+    let apyBreakdowns = await getApys();
+
+    if (Object.keys(apyBreakdowns).length === 0) {
+      throw 'There is no APY Breakdowns data yet';
+    }
+
+    ctx.status = 200;
+    ctx.body = apyBreakdowns;
+  } catch (err) {
+    ctx.throw(500, err);
+  }
+}
+
+module.exports = { apy, apyBreakdowns };

--- a/src/api/stats/index.js
+++ b/src/api/stats/index.js
@@ -7,7 +7,8 @@ const TIMEOUT = 5 * 60 * 1000;
 async function apy(ctx) {
   try {
     ctx.request.socket.setTimeout(TIMEOUT);
-    let apys = await getApys();
+    let apyObject = await getApys();
+    let apys = apyObject.apys;
 
     if (Object.keys(apys).length === 0) {
       throw 'There is no APYs data yet';
@@ -23,7 +24,8 @@ async function apy(ctx) {
 async function apyBreakdowns(ctx) {
   try {
     ctx.request.socket.setTimeout(TIMEOUT);
-    let apyBreakdowns = await getApys();
+    let apyObject = await getApys();
+    let apyBreakdowns = apyObject.apyBreakdowns;
 
     if (Object.keys(apyBreakdowns).length === 0) {
       throw 'There is no APY Breakdowns data yet';

--- a/src/router.js
+++ b/src/router.js
@@ -12,6 +12,8 @@ const cmc = require('./api/cmc');
 const tvl = require('./api/tvl');
 
 router.get('/apy', stats.apy);
+router.get('/apy/breakdown', stats.apyBreakdowns);
+
 router.get('/tvl', tvl.vaultTvl);
 router.get('/cmc', cmc.vaults);
 


### PR DESCRIPTION
PR creates a new endpoint in the API at /apy/breakdown. New endpoint was requested from Weso.

First PR brings in SpookyLPs, pauses to check that we like the format and then future PR(s) will iterate through LPs that are compatible with the new APY endpoint and have all the parameters required to expose these extra values.

Existing /apy endpoint is left as it was and has been referred to as the 'legacy' APY endpoint in the code.

In order to maintain both endpoints until we are able to migrate to the new /apy/breakdown endpoint fully, if we would like to, we need to maintain both object structures. We create an object that holds apy: and apyBreakdowns: objects and append to these in the same way we did before. At each level, we then check for the existence of these structures and continue breaking them out from the platform level LPs all the way up to getApys.

For this PR with spooky, this breakdown happens in getSpookyLpApys -> index.js (Fantom level) -> getApys -> index.js (Stats Level).

At the LP level, this PR aims to expose as much of the totalAPY logic as feels appropriate. This has included:

simpleApy - yearlyRewardsInUsd / totalStakedInUsd
compoundingsPerYear - BASE_HYP pulled from constants
beefyPerformanceFee - 0.045 or (1-0.955), which has also been refactored to a variable
vaultApy - simpleApy compounded
lpFee - Liquidity provider fee specific to platform
tradingApy - Pulled from Apollo (Subgraph)
totalApy - Full compounded APY using full calculation. This value is the same as the only value in the legacy /apy endpoint

Where the values are not available and therefore cannot be exposed in both the new and legacy formats, the legacy format is brought forward and mapped into the new endpoint. This means that you will see the totalApy for vaults where the breakdown does not exist.
