### PR TITLE
re-enable ApeSwap trading fees

### DIFF
--- a/src/api/stats/bsc/degens/getApeApys.js
+++ b/src/api/stats/bsc/degens/getApeApys.js
@@ -15,8 +15,8 @@ const getApeApys = async () => {
     oracle: 'tokens',
     decimals: '1e18',
     // log: true,
-    //  tradingFeeInfoClient: apeClient,
-    //  liquidityProviderFee: 0.0015,
+    tradingFeeInfoClient: apeClient,
+    liquidityProviderFee: 0.0015,
   });
 
   const banana = getMasterChefApys({

--- a/src/api/stats/bsc/mdex/getMdexBscLpApys.js
+++ b/src/api/stats/bsc/mdex/getMdexBscLpApys.js
@@ -28,8 +28,8 @@ const getMdexBscLpApys = async () => {
   const mdxPool = '0xc48FE252Aa631017dF253578B1405ea399728A50';
   const allPools = [...pools];
 
-  // const pairAddresses = pools.map(pool => pool.address);
-  // const tradingAprs = await getTradingFeeApr(mdexBscClient, pairAddresses, liquidityProviderFee);
+  const pairAddresses = pools.map(pool => pool.address);
+  const tradingAprs = {}; //await getTradingFeeApr(mdexBscClient, pairAddresses, liquidityProviderFee);
 
   let promises = [];
   allPools.forEach(pool => promises.push(getPoolApy(mdxPool, pool)));
@@ -39,10 +39,9 @@ const getMdexBscLpApys = async () => {
     const simpleApr = item.simpleApr;
     const vaultApr = simpleApr.times(shareAfterBeefyPerformanceFee);
     const vaultApy = compound(simpleApr, BASE_HPY, 1, shareAfterBeefyPerformanceFee);
-    //  const tradingApr = tradingAprs[item.address.toLowerCase()] ?? new BigNumber(0);
-    //  const totalApy = getFarmWithTradingFeesApy(simpleApr, tradingApr, BASE_HPY, 1, 0.955);
-    //  const legacyApyValue = { [item.name]: totalApy };
-    const legacyApyValue = { [item.name]: vaultApy };
+    const tradingApr = tradingAprs[item.address.toLowerCase()] ?? new BigNumber(0);
+    const totalApy = getFarmWithTradingFeesApy(simpleApr, tradingApr, BASE_HPY, 1, 0.955);
+    const legacyApyValue = { [item.name]: totalApy };
     // Add token to APYs object
     apys = { ...apys, ...legacyApyValue };
 
@@ -53,10 +52,9 @@ const getMdexBscLpApys = async () => {
         compoundingsPerYear: BASE_HPY,
         beefyPerformanceFee: beefyPerformanceFee,
         vaultApy: vaultApy,
-        //  lpFee: liquidityProviderFee,
-        //  tradingApr: tradingApr.toNumber(),
-        //  totalApy: totalApy,
-        totalApy: vaultApy,
+        lpFee: liquidityProviderFee,
+        tradingApr: tradingApr.toNumber(),
+        totalApy: totalApy,
       },
     };
     // Add token to APYs object

--- a/src/api/stats/heco/getMdexLpApys.js
+++ b/src/api/stats/heco/getMdexLpApys.js
@@ -22,8 +22,8 @@ const getMdexLpApys = async () => {
   let apys = {};
   let apyBreakdowns = {};
 
-  // const pairAddresses = pools.map(pool => pool.address);
-  // const tradingAprs = await getTradingFeeApr(mdexHecoClient, pairAddresses, liquidityProviderFee);
+  const pairAddresses = pools.map(pool => pool.address);
+  const tradingAprs = {}; //await getTradingFeeApr(mdexHecoClient, pairAddresses, liquidityProviderFee);
 
   const allPools = [...pools];
 
@@ -35,10 +35,9 @@ const getMdexLpApys = async () => {
     const simpleApr = item.simpleApr;
     const vaultApr = simpleApr.times(shareAfterBeefyPerformanceFee);
     const vaultApy = compound(simpleApr, BASE_HPY, 1, shareAfterBeefyPerformanceFee);
-    //  const tradingApr = tradingAprs[item.address.toLowerCase()] ?? new BigNumber(0);
-    //  const totalApy = getFarmWithTradingFeesApy(simpleApr, tradingApr, BASE_HPY, 1, 0.955);
-    //  const legacyApyValue = { [item.name]: totalApy };
-    const legacyApyValue = { [item.name]: vaultApy };
+    const tradingApr = tradingAprs[item.address.toLowerCase()] ?? new BigNumber(0);
+    const totalApy = getFarmWithTradingFeesApy(simpleApr, tradingApr, BASE_HPY, 1, 0.955);
+    const legacyApyValue = { [item.name]: totalApy };
     // Add token to APYs object
     apys = { ...apys, ...legacyApyValue };
 
@@ -50,9 +49,8 @@ const getMdexLpApys = async () => {
         beefyPerformanceFee: beefyPerformanceFee,
         vaultApy: vaultApy,
         lpFee: liquidityProviderFee,
-        //  tradingApr: tradingApr.toNumber(),
-        //  totalApy: totalApy,
-        totalApy: vaultApy,
+        tradingApr: tradingApr.toNumber(),
+        totalApy: totalApy,
       },
     };
     // Add token to APYs object


### PR DESCRIPTION
ApeSwap's graph endpoint seems to be up and running again.

Also adds try-catch to `getTradingFeeApr`, this should ensure we still return the vault APY when an external graph API is unavailable in the future.

(Mdex is still disabled)