### PR TITLE
Update prettier package to fix prettier bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dotenv": "^8.2.0",
     "nodemon": "^2.0.6",
     "nyc": "^15.1.0",
-    "prettier": "2.1.1",
+    "prettier": "^2.3.2",
     "yargs": "^17.0.1"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4801,10 +4801,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
-  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
+prettier@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-ms@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
Updating prettier package fixes this error when running the prettier yarn scripts: 

packages\address-book\util\convertSymbolTokenMapToAddressTokenMap.ts: SyntaxError: ']' expected. (5:31)
[error]   3 | export type AddressToTokenMap<T extends Record<string, Token>> = {
[error]   4 |   // prettier-ignore
[error] > 5 |   readonly [Obj in T[keyof T] as Obj["address"]]: Obj;
[error]     |                               ^
[error]   6 | };
[error]   7 | 
[error]   8 | export function convertSymbolTokenMapToAddressTokenMap<