### PR TITLE
Add Strategies to Vault API

### DIFF
--- a/src/abis/BeefyStrategyMulticall.json
+++ b/src/abis/BeefyStrategyMulticall.json
@@ -1,0 +1,21 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "vaults",
+        "type": "address[]"
+      }
+    ],
+    "name": "getStrategy",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/api/stats/getMultichainVaults.js
+++ b/src/api/stats/getMultichainVaults.js
@@ -1,4 +1,5 @@
 const getVaults = require('../../utils/getVaults.js');
+const { getStrategies } = require('../../utils/getStrategies.js');
 
 const { MULTICHAIN_ENDPOINTS } = require('../../constants');
 
@@ -24,7 +25,8 @@ const updateMultichainVaults = async () => {
   try {
     for (let chain in MULTICHAIN_ENDPOINTS) {
       let endpoint = MULTICHAIN_ENDPOINTS[chain];
-      let chainVaults = await getVaults(endpoint);
+      let chainVaultsNoStrategies = await getVaults(endpoint);
+      let chainVaults = await getStrategies(chainVaultsNoStrategies, chain);
 
       var chainVaultsCounter = 0;
       var chainActiveVaultsCounter = 0;

--- a/src/utils/getStrategies.js
+++ b/src/utils/getStrategies.js
@@ -1,0 +1,36 @@
+const { ethers } = require('ethers');
+const { MULTICHAIN_RPC } = require('../constants');
+import { ChainId } from '../../packages/address-book/address-book';
+
+const MULTICALLS = {
+  bsc: '0x88A3fB4Dcb566ee39ec3a03d412682536F9941e6',
+  heco: '0xaa5a5AD8a27fEd7F791952705ce90134eac620dc',
+  polygon: '0x78E156a612a7e907E4cF4340c9261608B0C19FEF',
+  fantom: '0x167615dBA34c173efF4b7ba7178fE174b472429D',
+  avax: '0x5135C0af3080DF01ABF66491d5a1eD21fBEF3a7C',
+};
+const BATCH_SIZE = 128;
+
+const MulticallAbi = require('../abis/BeefyStrategyMulticall.json');
+
+const getStrategies = async (vaults, chain) => {
+  // Setup multichain
+  const provider = new ethers.providers.JsonRpcProvider(MULTICHAIN_RPC[ChainId[chain]]);
+  const multicall = new ethers.Contract(MULTICALLS[chain], MulticallAbi, provider);
+
+  // Split query in batches
+  const query = vaults.map(v => v.earnedTokenAddress);
+  for (let i = 0; i < vaults.length; i += BATCH_SIZE) {
+    let batch = query.slice(i, i + BATCH_SIZE);
+    const buf = await multicall.getStrategy(batch);
+
+    // Merge fetched data
+    for (let j = 0; j < batch.length; j++) {
+      vaults[j + i].strategy = buf[j];
+    }
+  }
+
+  return vaults;
+};
+
+module.exports = { getStrategies };


### PR DESCRIPTION
Similar to the `fetchAmmPrices` helper, the `getStrategies` helper uses on chain data to find the active strategy on every vault. The strategy address is added into the vault information.

BSC Multicall: [0x88A3fB4Dcb566ee39ec3a03d412682536F9941e6](https://bscscan.com/address/0x88A3fB4Dcb566ee39ec3a03d412682536F9941e6)
Heco Multicall: [0xaa5a5AD8a27fEd7F791952705ce90134eac620dc](https://hecoinfo.com/address/0xaa5a5ad8a27fed7f791952705ce90134eac620dc)
Polygon Multicall: [0x78E156a612a7e907E4cF4340c9261608B0C19FEF](https://polygonscan.com/address/0x78E156a612a7e907E4cF4340c9261608B0C19FEF)
Fantom Multicall: [0x167615dBA34c173efF4b7ba7178fE174b472429D](https://ftmscan.com/address/0x167615dBA34c173efF4b7ba7178fE174b472429D)
AVAX Multicall: [0x5135C0af3080DF01ABF66491d5a1eD21fBEF3a7C](https://avascan.info/blockchain/c/address/0x5135C0af3080DF01ABF66491d5a1eD21fBEF3a7C)
