### PR TITLE
Added QuickSwap ETH-renDOGE

### DIFF
--- a/packages/address-book/address-book/polygon/tokens/tokens.ts
+++ b/packages/address-book/address-book/polygon/tokens/tokens.ts
@@ -1055,12 +1055,13 @@ const _tokens = {
   },
   renDOGE: {
     name: 'renDOGE',
-    address: '0x7C4A54f5d20b4023D6746F1f765f4DFe7C39a7e6',
+    address: '0xcE829A89d4A55a63418bcC43F00145adef0eDB8E',
     symbol: 'renDOGE',
     decimals: 8,
     chainId: 137,
-    logoURI:
-      'https://raw.githubusercontent.com/sushiswap/assets/master/blockchains/polygon/assets/0x7C4A54f5d20b4023D6746F1f765f4DFe7C39a7e6/logo.png',
+    website: 'https://renproject.io/',
+    description: 'renDOGE is a one-for-one representation of Dogecoin (DOGE) on Polygon via RenVM.',
+    logoURI: 'https://polygonscan.com/token/images/rendogecoin_32.png',
   },
   SNX: {
     name: 'SNX',

--- a/src/data/matic/quickLpPools.json
+++ b/src/data/matic/quickLpPools.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "quick-eth-rendoge",
+    "address": "0xAB1403De66519B898b38028357B74DF394a54a37",
+    "rewardPool": "0xe2519a7b81Cf038C055ddD667A9c06A0790945f4",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+      "oracle": "tokens",
+      "oracleId": "ETH",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xcE829A89d4A55a63418bcC43F00145adef0eDB8E",
+      "oracle": "tokens",
+      "oracleId": "renDOGE",
+      "decimals": "1e8"
+    }
+  },
+  {
     "name": "quick-usdc-quick",
     "address": "0x1F1E4c845183EF6d50E9609F16f6f9cAE43BC9Cb",
     "rewardPool": "0x8cFad56Eb742BA8CAEA813e47779E9C38f27cA6E",


### PR DESCRIPTION
ETH-renDOGE APY: 126%

Changed renDOGE's address because the previous one was the PoS address. 
If you don't like replacing it I could add it with a different name.