### PR TITLE
Fix Elk reward addresses

### DIFF
--- a/src/data/degens/elkLpPools.json
+++ b/src/data/degens/elkLpPools.json
@@ -2,7 +2,7 @@
   {
     "name": "elk-elk-bnb",
     "address": "0x6aDB3c5a9673ffFe6502e3bdEC465AdC91Ab3C01",
-    "rewardPool": "0x4FC3fB1f61B1953375BE44b9922c447c34a677b0",
+    "rewardPool": "0xEEc012BF435987BD370455Bb020709493DDB5C59",
     "decimals": "1e18",
     "chainId": 56,
     "lp0": {
@@ -21,7 +21,7 @@
   {
     "name": "elk-elk-dai",
     "address": "0xFDB340B7902B5DC6A0F3434246767BFfA841b9c1",
-    "rewardPool": "0xf2E696D11bB7a74e44DB7a2a98d5AfDD066caf97",
+    "rewardPool": "0x20Ab0ae3167b3Df014A3Aa18fbB2d45a4308af50",
     "decimals": "1e18",
     "chainId": 56,
     "lp0": {


### PR DESCRIPTION
To be merged when the strategy upgrades go through for ELK-BNB & ELK-DAI.

ELK-BNB vault: [0x69B2f487B2eDD9E272211f7CD8f57C1cddE0764E](https://bscscan.com/address/0x69B2f487B2eDD9E272211f7CD8f57C1cddE0764E)
ELK-DAI vault: [0x41a6CdA789316B2Fa5D824EF27E4223872E4cB34](https://bscscan.com/address/0x41a6CdA789316B2Fa5D824EF27E4223872E4cB34)