### PR TITLE
Add QuickSwap USDC-BNB (Relay BNB)

### DIFF
--- a/packages/address-book/address-book/polygon/tokens/tokens.ts
+++ b/packages/address-book/address-book/polygon/tokens/tokens.ts
@@ -1271,6 +1271,18 @@ const _tokens = {
     logoURI:
       'https://exchange.pancakeswap.finance/images/coins/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c.png',
   },
+  rBNB: {
+    name: 'Relay Bridge Polygon Binance Coin',
+    symbol: 'BNB',
+    address: '0x5c4b7CCBF908E64F32e12c6650ec0C96d717f03F',
+    chainId: 137,
+    decimals: 18,
+    website: 'https://www.binance.com/',
+    description:
+      'Binance Coin (BNB) is an exchange-based token created and issued by the cryptocurrency exchange Binance. Initially created on the Ethereum blockchain as an ERC-20 token in July 2017, BNB was migrated over to Binance Chain in February 2019 and became the native coin of the Binance Chain.',
+    logoURI:
+      'https://exchange.pancakeswap.finance/images/coins/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c.png',
+  },
   PBNB: {
     name: 'Orbit Bridge Polygon Binance Coin',
     symbol: 'PBNB',

--- a/src/data/matic/quickLpPools.json
+++ b/src/data/matic/quickLpPools.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "quick-usdc-rbnb",
+    "address": "0x40A5Df3E37152d4DaF279e0450289Af76472b02e",
+    "rewardPool": "0x3a353b71ae9b6C688ac474aD07632b8e0d499264",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0x5c4b7CCBF908E64F32e12c6650ec0C96d717f03F",
+      "oracle": "tokens",
+      "oracleId": "rBNB",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "quick-qi-eth",
     "address": "0x8C1b40Ea78081B70F661C3286c74E71b4602C9C0",
     "rewardPool": "0xb47f7120a57381c217e4d6F3a79F066bfAAe6C93",


### PR DESCRIPTION
This BNB is different to the existing one on Polygon from Anyswap, which is why it's marked as rBNB rather than just BNB.