### PR TITLE
Fix `compound` calls with mixed arguments (fixes #398).

### DIFF
--- a/src/api/stats/bsc/auto/getAutoApys.js
+++ b/src/api/stats/bsc/auto/getAutoApys.js
@@ -18,7 +18,7 @@ const getAutoApys = async () => {
 
     const apr = Number(poolStat['APR'] ?? 0);
     const aprAuto = Number(poolStat['APR_AUTO'] ?? 0);
-    const apy = compound(apr + aprAuto * 0.955, BASE_HPY, 1);
+    const apy = compound(apr + aprAuto * 0.955, BASE_HPY, 1, 1);
 
     // console.log(pool.name, apy);
 

--- a/src/api/stats/bsc/belt/getBeltApys.js
+++ b/src/api/stats/bsc/belt/getBeltApys.js
@@ -36,7 +36,7 @@ const getPoolApy = async (masterchef, pool) => {
   ]);
   let simpleApy = yearlyRewardsInUsd.dividedBy(totalStakedInUsd);
   const baseApy = await fetchBeltLpBaseApr(pool);
-  const apy = compound(baseApy + simpleApy * 0.955, process.env.BASE_HPY, 1);
+  const apy = compound(baseApy + simpleApy * 0.955, process.env.BASE_HPY, 1, 1);
   // console.log(pool.name, baseApy.valueOf(), simpleApy.valueOf(), apy, totalStakedInUsd.valueOf(), yearlyRewardsInUsd.valueOf());
   return { [pool.name]: apy };
 };

--- a/src/api/stats/bsc/fortress/getFortressApys.js
+++ b/src/api/stats/bsc/fortress/getFortressApys.js
@@ -31,15 +31,11 @@ const getPoolApy = async pool => {
     getBorrowApys(pool),
   ]);
 
-  const {
-    leveragedSupplyBase,
-    leveragedBorrowBase,
-    leveragedSupplyFts,
-    leveragedBorrowFts,
-  } = getLeveragedApys(supplyBase, borrowBase, supplyFts, borrowFts, 4, 0.58);
+  const { leveragedSupplyBase, leveragedBorrowBase, leveragedSupplyFts, leveragedBorrowFts } =
+    getLeveragedApys(supplyBase, borrowBase, supplyFts, borrowFts, 4, 0.58);
 
   const totalFts = leveragedSupplyFts.plus(leveragedBorrowFts);
-  const compoundedFts = compound(totalFts, BASE_HPY, 0.955);
+  const compoundedFts = compound(totalFts, BASE_HPY, 1, 0.955);
   const apy = leveragedSupplyBase.minus(leveragedBorrowBase).plus(compoundedFts).toNumber();
 
   // console.log(pool.name, 'base', supplyBase.valueOf(), supplyFts.valueOf(), borrowBase.valueOf(), borrowFts.valueOf());
@@ -52,21 +48,15 @@ const getSupplyApys = async pool => {
   const vtokenContract = new web3.eth.Contract(VToken, pool.vtoken);
   const unitrollerContract = new web3.eth.Contract(IUnitroller, UNITROLLER);
 
-  let [
-    fortressPrice,
-    tokenPrice,
-    supplyRate,
-    fortressRate,
-    totalSupply,
-    exchangeRateStored,
-  ] = await Promise.all([
-    fetchPrice({ oracle: 'tokens', id: 'FTS' }),
-    fetchPrice({ oracle: pool.oracle, id: pool.oracleId }),
-    vtokenContract.methods.supplyRatePerBlock().call(),
-    unitrollerContract.methods.fortressSpeeds(pool.vtoken).call(),
-    vtokenContract.methods.totalSupply().call(),
-    vtokenContract.methods.exchangeRateStored().call(),
-  ]);
+  let [fortressPrice, tokenPrice, supplyRate, fortressRate, totalSupply, exchangeRateStored] =
+    await Promise.all([
+      fetchPrice({ oracle: 'tokens', id: 'FTS' }),
+      fetchPrice({ oracle: pool.oracle, id: pool.oracleId }),
+      vtokenContract.methods.supplyRatePerBlock().call(),
+      unitrollerContract.methods.fortressSpeeds(pool.vtoken).call(),
+      vtokenContract.methods.totalSupply().call(),
+      vtokenContract.methods.exchangeRateStored().call(),
+    ]);
 
   supplyRate = new BigNumber(supplyRate);
   fortressRate = new BigNumber(fortressRate);

--- a/src/api/stats/bsc/venus/getVenusApys.js
+++ b/src/api/stats/bsc/venus/getVenusApys.js
@@ -33,15 +33,11 @@ const getPoolApy = async pool => {
     getBorrowApys(pool),
   ]);
 
-  const {
-    leveragedSupplyBase,
-    leveragedBorrowBase,
-    leveragedSupplyVxs,
-    leveragedBorrowVxs,
-  } = getLeveragedApys(supplyBase, borrowBase, supplyVxs, borrowVxs, 4, 0.58);
+  const { leveragedSupplyBase, leveragedBorrowBase, leveragedSupplyVxs, leveragedBorrowVxs } =
+    getLeveragedApys(supplyBase, borrowBase, supplyVxs, borrowVxs, 4, 0.58);
 
   const totalVxs = leveragedSupplyVxs.plus(leveragedBorrowVxs);
-  const compoundedVxs = compound(totalVxs, BASE_HPY, 0.955);
+  const compoundedVxs = compound(totalVxs, BASE_HPY, 1, 0.955);
   const apy = leveragedSupplyBase.minus(leveragedBorrowBase).plus(compoundedVxs).toNumber();
   return { [pool.name]: apy };
 };
@@ -50,21 +46,15 @@ const getSupplyApys = async pool => {
   const vtokenContract = new web3.eth.Contract(VToken, pool.vtoken);
   const unitrollerContract = new web3.eth.Contract(IUnitroller, UNITROLLER);
 
-  let [
-    venusPrice,
-    tokenPrice,
-    supplyRate,
-    venusRate,
-    totalSupply,
-    exchangeRateStored,
-  ] = await Promise.all([
-    fetchPrice({ oracle: 'tokens', id: 'XVS' }),
-    fetchPrice({ oracle: pool.oracle, id: pool.oracleId }),
-    vtokenContract.methods.supplyRatePerBlock().call(),
-    unitrollerContract.methods.venusSpeeds(pool.vtoken).call(),
-    vtokenContract.methods.totalSupply().call(),
-    vtokenContract.methods.exchangeRateStored().call(),
-  ]);
+  let [venusPrice, tokenPrice, supplyRate, venusRate, totalSupply, exchangeRateStored] =
+    await Promise.all([
+      fetchPrice({ oracle: 'tokens', id: 'XVS' }),
+      fetchPrice({ oracle: pool.oracle, id: pool.oracleId }),
+      vtokenContract.methods.supplyRatePerBlock().call(),
+      unitrollerContract.methods.venusSpeeds(pool.vtoken).call(),
+      vtokenContract.methods.totalSupply().call(),
+      vtokenContract.methods.exchangeRateStored().call(),
+    ]);
 
   supplyRate = new BigNumber(supplyRate);
   venusRate = new BigNumber(venusRate);

--- a/src/api/stats/fantom/getScreamApys.js
+++ b/src/api/stats/fantom/getScreamApys.js
@@ -45,7 +45,7 @@ const getPoolApy = async pool => {
     );
 
   const totalVxs = leveragedSupplyVxs.plus(leveragedBorrowVxs);
-  const compoundedVxs = compound(totalVxs, BASE_HPY, 0.955);
+  const compoundedVxs = compound(totalVxs, BASE_HPY, 1, 0.955);
   const apy = leveragedSupplyBase.minus(leveragedBorrowBase).plus(compoundedVxs).toNumber();
   return { [pool.name]: apy };
 };

--- a/src/api/stats/heco/getHfiApys.js
+++ b/src/api/stats/heco/getHfiApys.js
@@ -17,7 +17,7 @@ const getHfiApys = async () => {
     const vaultDec = vaultApy / 100;
     const aprHfi = Number(poolStat['hfi_annual']);
     const aprDec = aprHfi / 100;
-    const hfiApy = compound(aprDec * 0.955, BASE_HPY, 1);
+    const hfiApy = compound(aprDec * 0.955, BASE_HPY, 1, 1);
     const apy = vaultDec + hfiApy;
 
     // console.log(pool.name, apy);

--- a/src/api/stats/heco/getLendhubApys.js
+++ b/src/api/stats/heco/getLendhubApys.js
@@ -33,22 +33,18 @@ const getPoolApy = async pool => {
     getBorrowApys(pool),
   ]);
 
-  const {
-    leveragedSupplyBase,
-    leveragedBorrowBase,
-    leveragedSupplyVxs,
-    leveragedBorrowVxs,
-  } = getLeveragedApys(
-    supplyBase,
-    borrowBase,
-    supplyVxs,
-    borrowVxs,
-    pool.borrowDepth,
-    pool.borrowPercent
-  );
+  const { leveragedSupplyBase, leveragedBorrowBase, leveragedSupplyVxs, leveragedBorrowVxs } =
+    getLeveragedApys(
+      supplyBase,
+      borrowBase,
+      supplyVxs,
+      borrowVxs,
+      pool.borrowDepth,
+      pool.borrowPercent
+    );
 
   const totalVxs = leveragedSupplyVxs.plus(leveragedBorrowVxs);
-  const compoundedVxs = compound(totalVxs, BASE_HPY, 0.955);
+  const compoundedVxs = compound(totalVxs, BASE_HPY, 1, 0.955);
   const apy = leveragedSupplyBase.minus(leveragedBorrowBase).plus(compoundedVxs).toNumber();
   return { [pool.name]: apy };
 };
@@ -57,21 +53,15 @@ const getSupplyApys = async pool => {
   const itokenContract = new web3.eth.Contract(IToken, pool.itoken);
   const comptrollerContract = new web3.eth.Contract(Comptroller, COMPTROLLER);
 
-  let [
-    lhbPrice,
-    tokenPrice,
-    supplyRate,
-    compRate,
-    totalSupply,
-    exchangeRateStored,
-  ] = await Promise.all([
-    fetchPrice({ oracle: 'tokens', id: 'LHB' }),
-    fetchPrice({ oracle: pool.oracle, id: pool.oracleId }),
-    itokenContract.methods.supplyRatePerBlock().call(),
-    comptrollerContract.methods.compSpeeds(pool.itoken).call(),
-    itokenContract.methods.totalSupply().call(),
-    itokenContract.methods.exchangeRateStored().call(),
-  ]);
+  let [lhbPrice, tokenPrice, supplyRate, compRate, totalSupply, exchangeRateStored] =
+    await Promise.all([
+      fetchPrice({ oracle: 'tokens', id: 'LHB' }),
+      fetchPrice({ oracle: pool.oracle, id: pool.oracleId }),
+      itokenContract.methods.supplyRatePerBlock().call(),
+      comptrollerContract.methods.compSpeeds(pool.itoken).call(),
+      itokenContract.methods.totalSupply().call(),
+      itokenContract.methods.exchangeRateStored().call(),
+    ]);
 
   supplyRate = new BigNumber(supplyRate);
   compRate = new BigNumber(compRate);

--- a/src/api/stats/matic/getAaveApys.js
+++ b/src/api/stats/matic/getAaveApys.js
@@ -44,22 +44,18 @@ const getAaveApys = async () => {
 const getPoolApy = async pool => {
   const { supplyBase, supplyMatic, borrowBase, borrowMatic } = await getAavePoolData(pool);
 
-  const {
-    leveragedSupplyBase,
-    leveragedBorrowBase,
-    leveragedSupplyMatic,
-    leveragedBorrowMatic,
-  } = getLeveragedApys(
-    supplyBase,
-    borrowBase,
-    supplyMatic,
-    borrowMatic,
-    pool.borrowDepth,
-    pool.borrowPercent
-  );
+  const { leveragedSupplyBase, leveragedBorrowBase, leveragedSupplyMatic, leveragedBorrowMatic } =
+    getLeveragedApys(
+      supplyBase,
+      borrowBase,
+      supplyMatic,
+      borrowMatic,
+      pool.borrowDepth,
+      pool.borrowPercent
+    );
 
   let totalMatic = leveragedSupplyMatic.plus(leveragedBorrowMatic);
-  let compoundedMatic = compound(totalMatic, BASE_HPY, 0.955);
+  let compoundedMatic = compound(totalMatic, BASE_HPY, 1, 0.955);
   let apy = leveragedSupplyBase.minus(leveragedBorrowBase).plus(compoundedMatic).toNumber();
   // console.log(pool.name, apy, supplyBase.valueOf(), borrowBase.valueOf(), supplyMatic.valueOf(), borrowMatic.valueOf());
   return { [pool.name]: apy };


### PR DESCRIPTION
Amended a couple of extra calls that weren't causing a miss calculation but could lead future developers to repeat the same mistake.