### PR TITLE
fix spirit-link-ftm

### DIFF
--- a/src/data/fantom/spiritPools.json
+++ b/src/data/fantom/spiritPools.json
@@ -344,6 +344,7 @@
     "name": "spirit-link-ftm",
     "address": "0xd061c6586670792331e14a80f3b3bb267189c681",
     "decimals": "1e18",
+    "poolId": 11,
     "chainId": 250,
     "lp0": {
       "address": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",


### PR DESCRIPTION
missing poolID