### PR TITLE
feat: add Last-Modified header for data refresh timestamp

### DIFF
--- a/src/api/stats/getMultichainVaults.js
+++ b/src/api/stats/getMultichainVaults.js
@@ -7,12 +7,18 @@ const { MULTICHAIN_ENDPOINTS } = require('../../constants');
 const INIT_DELAY = 0 * 1000;
 const REFRESH_INTERVAL = 5 * 60 * 1000;
 
+let dataRefreshTimestamp = null;
+
 let multichainVaults = [];
 var multichainVaultsCounter = 0;
 var multichainActiveVaultsCounter = 0;
 
 const getMultichainVaults = () => {
-  return multichainVaults;
+  return {
+    // Use the last data refresh timestamp in response headers as Last-Modified
+    dataRefreshTimestamp: dataRefreshTimestamp,
+    data: multichainVaults,
+  };
 };
 
 const updateMultichainVaults = async () => {
@@ -63,6 +69,8 @@ const updateMultichainVaults = async () => {
       multichainActiveVaultsCounter,
       'active )'
     );
+
+    dataRefreshTimestamp = Date.now();
   } catch (err) {
     console.error('> vaults update failed', err);
   }

--- a/src/api/vaults/index.js
+++ b/src/api/vaults/index.js
@@ -4,7 +4,8 @@ async function multichainVaults(ctx) {
   try {
     const multichainVaults = await getMultichainVaults();
     ctx.status = 200;
-    ctx.body = [...multichainVaults];
+    ctx.body = [...multichainVaults.data];
+    ctx.set('Last-Modified', multichainVaults.dataRefreshTimestamp);
   } catch (err) {
     console.error(err);
     ctx.status = 500;

--- a/src/api/vaults/index.js
+++ b/src/api/vaults/index.js
@@ -6,6 +6,7 @@ async function multichainVaults(ctx) {
     ctx.status = 200;
     ctx.body = [...multichainVaults.data];
     ctx.set('Last-Modified', multichainVaults.dataRefreshTimestamp);
+    ctx.set('Source-Last-Modified', multichainVaults.etagUpdateTimestamp);
   } catch (err) {
     console.error(err);
     ctx.status = 500;

--- a/src/utils/getVaults.js
+++ b/src/utils/getVaults.js
@@ -6,6 +6,10 @@ const getVaults = async vaultsEndpoint => {
 
     const data = response.data;
     const etag = response.headers.etag;
+
+    // Debugging source file updates
+    // console.log(etag)
+
     let vaults = '[' + data.substring(data.indexOf('\n') + 1);
     vaults = eval(vaults);
 

--- a/src/utils/getVaults.js
+++ b/src/utils/getVaults.js
@@ -3,10 +3,16 @@ const axios = require('axios');
 const getVaults = async vaultsEndpoint => {
   try {
     const response = await axios.get(vaultsEndpoint);
+
     const data = response.data;
+    const etag = response.headers.etag;
     let vaults = '[' + data.substring(data.indexOf('\n') + 1);
     vaults = eval(vaults);
-    return vaults;
+
+    return {
+      etag: etag,
+      vaults: vaults,
+    };
   } catch (err) {
     console.error(err);
     return 0;


### PR DESCRIPTION
Splits out getMultichainVaults return to a dictionary of:
```javascript
return {
    // Use the last data refresh timestamp in response headers as Last-Modified
    dataRefreshTimestamp: dataRefreshTimestamp,
    data: multichainVaults,
 };
```
 and then pulls the keys out explicitly into the JSON response for the API and moves the refresh timestamp into Last-Modified header.

Preserves the current schema of `/vaults` by just updating call headers.

Closes #452 