### PR TITLE
Fix price fetch for BNB on Avalanche

### DIFF
--- a/packages/address-book/address-book/avax/tokens/tokens.ts
+++ b/packages/address-book/address-book/avax/tokens/tokens.ts
@@ -138,7 +138,7 @@ const _tokens = {
     logoURI:
       'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/images/single-assets/BIFI.png',
   },
-  BNB: {
+  avaxBNB: {
     chainId: 43114,
     address: '0x264c1383EA520f73dd837F915ef3a732e204a493',
     decimals: 18,

--- a/src/data/avax/joeLpPools.json
+++ b/src/data/avax/joeLpPools.json
@@ -160,7 +160,7 @@
     "lp0": {
       "address": "0x264c1383EA520f73dd837F915ef3a732e204a493",
       "oracle": "tokens",
-      "oracleId": "BNB",
+      "oracleId": "avaxBNB",
       "decimals": "1e18"
     },
     "lp1": {


### PR DESCRIPTION
Currently it's using BNB, which is fetched as 0 from BSC.