### PR TITLE
feat: added /vaults/stake for BSC

### DIFF
--- a/src/api/stats/getMultichainStakeVaults.js
+++ b/src/api/stats/getMultichainStakeVaults.js
@@ -1,0 +1,71 @@
+const getStakeVaults = require('../../utils/getStakeVaults.js');
+
+const { MULTICHAIN_STAKE_VAULTS_ENDPOINTS } = require('../../constants');
+
+const INIT_DELAY = 0 * 1000;
+const REFRESH_INTERVAL = 5 * 60 * 1000;
+
+let multichainStakeVaults = [];
+var multichainStakeVaultsCounter = 0;
+var multichainActiveStakeVaultsCounter = 0;
+
+const getMultichainStakeVaults = () => {
+  return multichainStakeVaults;
+};
+
+const updateMultichainStakeVaults = async () => {
+  console.log('> updating staked vaults');
+
+  // Reset entire list and counters
+  multichainStakeVaults = [];
+  multichainStakeVaultsCounter = 0;
+  multichainActiveStakeVaultsCounter = 0;
+
+  try {
+    for (let chain in MULTICHAIN_STAKE_VAULTS_ENDPOINTS) {
+      let endpoint = MULTICHAIN_STAKE_VAULTS_ENDPOINTS[chain];
+      let chainStakeVaults = await getStakeVaults(endpoint);
+
+      var chainStakeVaultsCounter = 0;
+      var chainActiveStakeVaultsCounter = 0;
+
+      for (let vault in chainStakeVaults) {
+        chainStakeVaults[vault].chain = chain;
+        multichainStakeVaults.push(chainStakeVaults[vault]);
+
+        chainStakeVaultsCounter += 1;
+        multichainStakeVaultsCounter += 1;
+
+        if (chainStakeVaults[vault].status == 'active') {
+          chainActiveStakeVaultsCounter += 1;
+          multichainActiveStakeVaultsCounter += 1;
+        }
+      }
+
+      // console.log(
+      //   'Found',
+      //   chainVaultsCounter,
+      //   'vaults (',
+      //   chainActiveVaultsCounter,
+      //   'active ) in',
+      //   chain
+      // );
+    }
+
+    console.log(
+      '> updated',
+      multichainStakeVaultsCounter,
+      'stake vaults (',
+      multichainActiveStakeVaultsCounter,
+      'active )'
+    );
+  } catch (err) {
+    console.error('> staked vaults update failed', err);
+  }
+
+  setTimeout(updateMultichainStakeVaults, REFRESH_INTERVAL);
+};
+
+setTimeout(updateMultichainStakeVaults, INIT_DELAY);
+
+module.exports = getMultichainStakeVaults;

--- a/src/api/vaults/index.js
+++ b/src/api/vaults/index.js
@@ -1,4 +1,5 @@
 const getMultichainVaults = require('../stats/getMultichainVaults');
+const getMultichainStakeVaults = require('../stats/getMultichainStakeVaults');
 
 async function multichainVaults(ctx) {
   try {
@@ -11,6 +12,18 @@ async function multichainVaults(ctx) {
   }
 }
 
+async function multichainStakeVaults(ctx) {
+  try {
+    const multichainStakeVaults = await getMultichainStakeVaults();
+    ctx.status = 200;
+    ctx.body = [...multichainStakeVaults];
+  } catch (err) {
+    console.error(err);
+    ctx.status = 500;
+  }
+}
+
 module.exports = {
   multichainVaults,
+  multichainStakeVaults,
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -123,6 +123,16 @@ const MULTICHAIN_ENDPOINTS = {
   // aurora: AURORA_VAULTS_ENDPOINT,
 };
 
+const BSC_STAKE_VAULTS_ENDPOINT =
+  'https://raw.githubusercontent.com/beefyfinance/beefy-app/master/src/features/configure/stake/bsc_stake.js';
+
+const MULTICHAIN_STAKE_VAULTS_ENDPOINTS = {
+  bsc: BSC_STAKE_VAULTS_ENDPOINT,
+};
+
+const ABI_ENDPOINT =
+  'https://raw.githubusercontent.com/beefyfinance/beefy-app/master/src/features/configure/abi.js';
+
 const BEEFY_PERFORMANCE_FEE = 0.045;
 const SHARE_AFTER_PERFORMANCE_FEE = 1 - BEEFY_PERFORMANCE_FEE;
 
@@ -174,6 +184,8 @@ export {
   FORTUBE_API_TOKEN,
   MULTICHAIN_RPC,
   MULTICHAIN_ENDPOINTS,
+  MULTICHAIN_STAKE_VAULTS_ENDPOINTS,
+  ABI_ENDPOINT,
   DFYN_LPF,
   SUSHI_LPF,
   SPIRIT_LPF,

--- a/src/router.js
+++ b/src/router.js
@@ -31,6 +31,7 @@ router.get('/lps', price.lpsPrices);
 router.get('/prices', price.tokenPrices);
 
 router.get('/vaults', multichainVaults.multichainVaults);
+router.get('/vaults/stake', multichainVaults.multichainStakeVaults);
 
 router.get('/', noop);
 

--- a/src/utils/getStakeVaults.js
+++ b/src/utils/getStakeVaults.js
@@ -1,0 +1,33 @@
+const axios = require('axios');
+const fs = require('fs');
+const { sleep } = require('./time');
+const { ABI_ENDPOINT } = require('../constants');
+
+const getStakeVaults = async vaultsEndpoint => {
+  try {
+    const response = await axios.get(vaultsEndpoint);
+    const data = response.data;
+    fs.writeFile('src/utils/pools/stake/bsc_stake.js', data, function (err) {
+      if (err) return console.log(err);
+      // console.log('> stake pools sourced into src/utils/pools/stake/bsc_stake.js');
+    });
+
+    const abiResponse = await axios.get(ABI_ENDPOINT);
+    const abiData = abiResponse.data;
+    fs.writeFile('src/utils/pools/abi.js', abiData, function (err) {
+      if (err) return console.log(err);
+      // console.log('> abi sourced into src/utils/pools/abi.js');
+    });
+
+    await sleep(1000);
+
+    const bscStake = require('../utils/pools/stake/bsc_stake');
+
+    return bscStake.bscStakePools;
+  } catch (err) {
+    console.error(err);
+    return 0;
+  }
+};
+
+module.exports = getStakeVaults;


### PR DESCRIPTION
Creates a new endpoint, `vaults/stake` to expose the staked pools files JSON.

This PR only includes BSC pools on request from Pacoca and prioritises that requirment, but a further small refactor to include all chains would be very simple.

Schema:

``` typescript
interface stakeVaults {
    [
         {
             id: string,
             name: string,
             logo: string,
             token: string,
             tokenDecimals: number,
             tokenAddress: string,
             tokenOracle: string,
             tokenOracleId: string,
             earnedToken: string,
             earnedTokenDecimals: number,
             earnedTokenAddress: string,
             earnContractAddress: string,
             earnContractAbi: object,
             earnedOracle: string,
             earnedOracleId: string,
             partnership: boolean,
             status: string,
             fixedStatus: boolean,
             partners: object,
             chain: string,
         }
        ...
    ]
}
```