### PR TITLE
Add Jarvis 4eur

### DIFF
--- a/src/api/stats/common/getMasterChefApys.ts
+++ b/src/api/stats/common/getMasterChefApys.ts
@@ -24,6 +24,7 @@ export interface MasterChefApysParams {
   masterchef: string;
   masterchefAbi?: AbiItem[];
   tokenPerBlock: string;
+  totalAllocPoint?: number;
   hasMultiplier: boolean;
   singlePools?: SingleAssetPool[];
   pools?: LpPool[] | (LpPool | SingleAssetPool)[];
@@ -142,7 +143,7 @@ const getMasterChefData = async (params: MasterChefApysParams) => {
   const blockRewards = new BigNumber(
     await masterchefContract.methods[params.tokenPerBlock]().call()
   );
-  const totalAllocPoint = new BigNumber(await masterchefContract.methods.totalAllocPoint().call());
+  const totalAllocPoint = new BigNumber(params.totalAllocPoint) ?? new BigNumber(await masterchefContract.methods.totalAllocPoint().call());
   return { multiplier, blockRewards, totalAllocPoint };
 };
 

--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -371,7 +371,7 @@ const pools = [
 
 const dmmPools = [...kyberPools];
 
-const coinGeckoCoins = ['stasis-eurs', 'tether-eurt'];
+const coinGeckoCoins = ['stasis-eurs', 'tether-eurt', 'par-stablecoin', 'jarvis-synthetic-euro'];
 
 const knownPrices = {
   BUSD: 1,

--- a/src/api/stats/getNonAmmPrices.ts
+++ b/src/api/stats/getNonAmmPrices.ts
@@ -13,6 +13,7 @@ import getCurveAvaxPrices from './avax/getCurvePrices';
 import getCurveHarmonyPrices from './one/getCurvePrices';
 import getBeethovenxPrices from './fantom/getBeethovenxPrices';
 import { getSynapsePrices } from './avax/getSynapsePrices';
+import getJarvisPrices from './matic/getJarvisPrices';
 
 const getNonAmmPrices = async tokenPrices => {
   let prices = {};
@@ -33,6 +34,7 @@ const getNonAmmPrices = async tokenPrices => {
     getIronSwapPrices(),
     getAlpacaIbPrices(tokenPrices),
     getSynapsePrices(),
+    getJarvisPrices(tokenPrices),
   ];
 
   // Setup error logs

--- a/src/api/stats/matic/getJarvisApys.js
+++ b/src/api/stats/matic/getJarvisApys.js
@@ -1,0 +1,32 @@
+const { polygonWeb3: web3 } = require('../../../utils/web3');
+import { POLYGON_CHAIN_ID as chainId } from '../../../constants';
+import { getMasterChefApys } from '../common/getMasterChefApys';
+import { getCurveFactoryApy } from '../common/curve/getCurveApyData';
+
+import pools from '../../../data/matic/jarvisPools.json';
+
+const getJarvisApys = async () => {
+  const pool = '0xAd326c253A84e9805559b73A08724e11E49ca651';
+  const tradingAprs = await getCurveFactoryApy(
+    pool,
+    'https://api.curve.fi/api/getFactoryAPYs-polygon'
+  );
+  return await getMasterChefApys({
+    web3: web3,
+    chainId: chainId,
+    masterchef: '0xf8347d0C225e26B45A6ea9a719012F1153D7Ca15',
+    tokenPerBlock: 'rwdPerBlock',
+    totalAllocPoint: 23,
+    hasMultiplier: false,
+    pools: pools,
+    oracleId: 'DEN',
+    oracle: 'lps',
+    decimals: '1e18',
+    tradingAprs: tradingAprs,
+    // log: true,
+  });
+};
+
+module.exports = { getJarvisApys };
+
+

--- a/src/api/stats/matic/getJarvisPrices.ts
+++ b/src/api/stats/matic/getJarvisPrices.ts
@@ -1,0 +1,13 @@
+const getCurvePricesCommon = require('../common/curve/getCurvePricesCommon');
+const { polygonWeb3: web3 } = require('../../../utils/web3');
+const pools = require('../../../data/matic/jarvisPools.json');
+const rewardPool = require('../../../data/matic/jarvisRewardPool.json');
+import { fetchDmmPrices } from '../../../utils/fetchDmmPrices';
+
+const getJarvisPrices = async tokenPrices => {
+  const curvePrices = await getCurvePricesCommon(web3, pools, tokenPrices);
+  const dmmPrices = await fetchDmmPrices(rewardPool, curvePrices);
+  return dmmPrices.tokenPrices;
+};
+
+module.exports = getJarvisPrices;

--- a/src/api/stats/matic/index.js
+++ b/src/api/stats/matic/index.js
@@ -37,6 +37,7 @@ const { getSingularApys } = require('./getSingularApys');
 import getCafeLpApys from './getCafeLpApys';
 import getKyberLpApys from './getKyberLpApys';
 import { getQuickDualLpApys } from './getQuickDualLpApys';
+import { getJarvisApys } from './getJarvisApys';
 
 const getApys = [
   getComethLpApys,
@@ -78,6 +79,7 @@ const getApys = [
   getCafeLpApys,
   getKyberLpApys,
   getQuickDualLpApys,
+  getJarvisApys,
 ];
 
 const BATCH_SIZE = 15;

--- a/src/data/matic/jarvisPools.json
+++ b/src/data/matic/jarvisPools.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "jarvis-4eur",
+    "pool": "0xAd326c253A84e9805559b73A08724e11E49ca651",
+    "address": "0xAd326c253A84e9805559b73A08724e11E49ca651",
+    "poolId": 1,
+    "chainId": 137,
+    "token": "0xAd326c253A84e9805559b73A08724e11E49ca651",
+    "baseApyKey": "4eur-f",
+    "volatile": true,
+    "tokens": [
+      {
+        "oracle": "tokens",
+        "oracleId": "jarvis-synthetic-euro",
+        "decimals": "1e18"
+      },
+      {
+        "oracle": "tokens",
+        "oracleId": "par-stablecoin",
+        "decimals": "1e18"
+      },
+      {
+        "oracle": "tokens",
+        "oracleId": "stasis-eurs",
+        "decimals": "1e2"
+      },
+      {
+        "oracle": "tokens",
+        "oracleId": "tether-eurt",
+        "decimals": "1e6"
+      }
+    ]
+  }
+]

--- a/src/data/matic/jarvisRewardPool.json
+++ b/src/data/matic/jarvisRewardPool.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "kyber-4eur-den",
+    "address": "0x4924B6E1207EFb244433294619a5ADD08ACB3dfF",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0xAd326c253A84e9805559b73A08724e11E49ca651",
+      "oracle": "tokens",
+      "oracleId": "jarvis-4eur",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xf379CB529aE58E1A03E62d3e31565f4f7c1F2020",
+      "oracle": "tokens",
+      "oracleId": "DEN",
+      "decimals": "1e18"
+    }
+  }
+]


### PR DESCRIPTION
Reward token DEN is only in DMM LP 4eur-DEN, which makes price finding more difficult since we need to find the price of the 4eur LP token first. DEN is therefore calculated in the nonAmmPrices section and is labelled as 'lps' in the oracle.

The Jarvis MC has `totalAllocPoints` rather than `totalAllocPoint`. However it is a fixed number. I've introduced a fixed total alloc point as an option on the `getMasterChefApys`.