### PR TITLE
Delever Blizz WETH

### DIFF
--- a/src/data/avax/blizzPools.json
+++ b/src/data/avax/blizzPools.json
@@ -117,8 +117,8 @@
     "oracle": "tokens",
     "oracleId": "WETH.e",
     "decimals": "1e18",
-    "borrowDepth": 4,
-    "borrowPercent": 0.77
+    "borrowDepth": 1,
+    "borrowPercent": 0.01
   },
   {
     "name": "blizz-wbtc",


### PR DESCRIPTION
APY was going negative without the vault representing a large portion of the pool TVL so only option was to move to supply-only.