### PR TITLE
Add SpiritSwap fUSDT-USDC, FRAX-USDC, MIM-USDC farms

### DIFF
--- a/src/data/fantom/spiritPools.json
+++ b/src/data/fantom/spiritPools.json
@@ -417,6 +417,63 @@
     }
   },
   {
+    "name": "spirit-fusdt-usdc",
+    "address": "0xe7F86CEf8FEf60ce5050899D1F8e465C00D04a79",
+    "decimals": "1e18",
+    "poolId": 65,
+    "chainId": 250,
+    "lp0": {
+      "address": "0x04068DA6C83AFCFA0e13ba15A6696662335D5B75",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0x049d68029688eAbF473097a2fC38ef61633A3C7A",
+      "oracle": "tokens",
+      "oracleId": "fUSDT",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "spirit-frax-usdc",
+    "address": "0x1478AEC7896e40aE5fB858C77D389F0B3e6CbC5d",
+    "decimals": "1e18",
+    "poolId": 66,
+    "chainId": 250,
+    "lp0": {
+      "address": "0x04068DA6C83AFCFA0e13ba15A6696662335D5B75",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0xdc301622e621166BD8E82f2cA0A26c13Ad0BE355",
+      "oracle": "tokens",
+      "oracleId": "FRAX",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "spirit-mim-usdc",
+    "address": "0xc19C7615237f770179ed93d89126478c60742664",
+    "decimals": "1e18",
+    "poolId": 67,
+    "chainId": 250,
+    "lp0": {
+      "address": "0x04068DA6C83AFCFA0e13ba15A6696662335D5B75",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0x82f0B8B456c1A451378467398982d4834b6829c1",
+      "oracle": "tokens",
+      "oracleId": "MIM",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "spirit-spell-sspell",
     "address": "0x4f41D03631Ea4dC14016CcF90690d6D22b24C12D",
     "decimals": "1e18",


### PR DESCRIPTION
Adding oracles for new stablecoin farms on SpiritSwap

### fUSDT-USDC

Vault: 0xFbfa12b10626151fB7735aBe4af5277104b480ee
Strategy: 0xf2e24273821835D177eB7A6C222c5AfE5de38e87
Want: 0xe7F86CEf8FEf60ce5050899D1F8e465C00D04a79
PoolId: 65

### FRAX-USDC

Vault: 0x11d4D27364952b972AC74Fb6676DbbFa67fDa72F
Strategy: 0x5ef24da9a51a577FE17a9385Ca9206A7266161B0
Want: 0x1478AEC7896e40aE5fB858C77D389F0B3e6CbC5d
PoolId: 66

### MIM-USDC

Vault: 0x3aA3341433E8efE228F75777213787f1a51Ab09d
Strategy: 0xA7Ba5D21CE2E9F002fa0348aA71f228a8974273B
Want: 0xc19C7615237f770179ed93d89126478c60742664
PoolId: 67