### PR TITLE
Add four traderJoe pools (dual rewards)

### DIFF
--- a/packages/address-book/address-book/avax/tokens/tokens.ts
+++ b/packages/address-book/address-book/avax/tokens/tokens.ts
@@ -15,6 +15,42 @@ const AVAX = {
 } as const;
 
 const _tokens = {
+  DCAU: {
+    name: 'Dragon Crypto Aurum DCAU',
+    symbol: 'DCAU',
+    address: '0x100Cc3a819Dd3e8573fD2E46D1E66ee866068f30',
+    chainId: 43114,
+    decimals: 18,
+    logoURI:
+      'https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0x100Cc3a819Dd3e8573fD2E46D1E66ee866068f30/logo.png',
+    website: 'https://aurum.dragoncrypto.io/',
+    description:
+      'Dragon Crypto Gaming (DCG), a Game-Fi platform which offers NFTs, play-to-earn games and yield farming.',
+  },
+  HEC: {
+    name: 'HeroesChained HEC',
+    symbol: 'HEC',
+    address: '0xC7f4debC8072e23fe9259A5C0398326d8EfB7f5c',
+    chainId: 43114,
+    decimals: 18,
+    logoURI:
+      'https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xC7f4debC8072e23fe9259A5C0398326d8EfB7f5c/logo.png',
+    website: 'https://heroeschained.com/',
+    description:
+      'Heroes Chained is a fantasy action RPG game, where the player becomes a Guild Master and gathers heroes.',
+  },
+  COOK: {
+    name: 'Cook COOK',
+    symbol: 'COOK',
+    address: '0x637afeff75ca669fF92e4570B14D6399A658902f',
+    chainId: 43114,
+    decimals: 18,
+    logoURI:
+      'https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0x637afeff75ca669fF92e4570B14D6399A658902f/logo.png',
+    website: 'https://app.cook.finance/',
+    description:
+      'Cook Protocol establishes a transparent and flexible asset management platform suited to diverse investors and asset management service providers alike.',
+  },
   UST: {
     name: 'Axelar Wrapped UST',
     symbol: 'UST',

--- a/src/data/avax/joeDualLpPools.json
+++ b/src/data/avax/joeDualLpPools.json
@@ -22,6 +22,94 @@
     }
   },
   {
+    "name": "joe-wavax-xava",
+    "address": "0x72c3438cf1c915EcF5D9F17A6eD346B273d5bF71",
+    "decimals": "1e18",
+    "poolId": 2,
+    "chainId": 43114,
+    "oracleB": "tokens",
+    "oracleIdB": "WAVAX",
+    "decimalsB": "1e18",
+    "lp0": {
+      "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      "oracle": "tokens",
+      "oracleId": "AVAX",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xd1c3f94DE7e5B45fa4eDBBA472491a9f4B166FC4",
+      "oracle": "tokens",
+      "oracleId": "XAVA",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "joe-wavax-cook",
+    "address": "0x3fcD1d5450e63FA6af495A601E6EA1230f01c4E3",
+    "decimals": "1e18",
+    "poolId": 37,
+    "chainId": 43114,
+    "oracleB": "tokens",
+    "oracleIdB": "COOK",
+    "decimalsB": "1e18",
+    "lp0": {
+      "address": "0x637afeff75ca669ff92e4570b14d6399a658902f",
+      "oracle": "tokens",
+      "oracleId": "COOK",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      "oracle": "tokens",
+      "oracleId": "AVAX",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "joe-wavax-dcau",
+    "address": "0x81034A38a124A3290DC226798f34c6645B153a02",
+    "decimals": "1e18",
+    "poolId": 40,
+    "chainId": 43114,
+    "oracleB": "tokens",
+    "oracleIdB": "DCAU",
+    "decimalsB": "1e18",
+    "lp0": {
+      "address": "0x100Cc3a819Dd3e8573fD2E46D1E66ee866068f30",
+      "oracle": "tokens",
+      "oracleId": "DCAU",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      "oracle": "tokens",
+      "oracleId": "AVAX",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "joe-wavax-hec",
+    "address": "0x4dC5291cdc7Ad03342994E35D0Ccc76De065A566",
+    "decimals": "1e18",
+    "poolId": 41,
+    "chainId": 43114,
+    "oracleB": "tokens",
+    "oracleIdB": "HEC",
+    "decimalsB": "1e18",
+    "lp0": {
+      "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      "oracle": "tokens",
+      "oracleId": "AVAX",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xC7f4debC8072e23fe9259A5C0398326d8EfB7f5c",
+      "oracle": "tokens",
+      "oracleId": "HEC",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "joe-gmx-wavax",
     "address": "0x0c91a070f862666bBcce281346BE45766d874D98",
     "decimals": "1e18",

--- a/src/data/avax/joeLpPools.json
+++ b/src/data/avax/joeLpPools.json
@@ -779,25 +779,6 @@
     }
   },
   {
-    "name": "joe-wavax-xava",
-    "address": "0x72c3438cf1c915EcF5D9F17A6eD346B273d5bF71",
-    "decimals": "1e18",
-    "poolId": 7,
-    "chainId": 43114,
-    "lp0": {
-      "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-      "oracle": "tokens",
-      "oracleId": "AVAX",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xd1c3f94DE7e5B45fa4eDBBA472491a9f4B166FC4",
-      "oracle": "tokens",
-      "oracleId": "XAVA",
-      "decimals": "1e18"
-    }
-  },
-  {
     "name": "joe-png-wavax",
     "address": "0x3dAF1C6268362214eBB064647555438c6f365F96",
     "decimals": "1e18",


### PR DESCRIPTION
AVAX-XAVA
Want: 0x72c3438cf1c915EcF5D9F17A6eD346B273d5bF71
PoolId: 2
RewardB: WAVAX

AVAX-COOK
Want: 0x3fcD1d5450e63FA6af495A601E6EA1230f01c4E3
PoolId: 37
RewardB: COOK)

AVAX-DCAU
Want: 0x81034A38a124A3290DC226798f34c6645B153a02
PoolId: 40
RewardB: DCAU

AVAX-HEC
Want: 0x4dC5291cdc7Ad03342994E35D0Ccc76De065A566
PoolId: 41
RewardB: HEC

Additionally removed old jow-wavax-xava entry. The AVAX-XAVA was previously single reward (different masterchef), but is now included in the dual rewards masterchef and gives JOE and WAVAX.