### PR TITLE
PangolinV2 dual rewards apy calculation

### DIFF
--- a/packages/address-book/address-book/avax/tokens/tokens.ts
+++ b/packages/address-book/address-book/avax/tokens/tokens.ts
@@ -15,6 +15,18 @@ const AVAX = {
 } as const;
 
 const _tokens = {
+  LOOT: {
+    name: 'Police and Thief Game LOOT',
+    symbol: 'LOOT',
+    address: '0x7f041ce89A2079873693207653b24C15B5e6A293',
+    chainId: 43114,
+    decimals: 18,
+    logoURI:
+      'https://raw.githubusercontent.com/pangolindex/tokens/main/assets/0x7f041ce89A2079873693207653b24C15B5e6A293/logo.png',
+    website: 'https://policeandthief.game/',
+    description:
+      'Police and Thief Game is a NFT P2E game on Avalanche, a Wolf Game derivative. The game incorporates probability based derivatives and decision making possibilities to allow players to make various decisions to come out on top.',
+  },
   DCAU: {
     name: 'Dragon Crypto Aurum DCAU',
     symbol: 'DCAU',

--- a/src/abis/avax/PangolinRewarderViaMultiplier.json
+++ b/src/abis/avax/PangolinRewarderViaMultiplier.json
@@ -1,0 +1,193 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "_rewardTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_rewardMultipliers",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_baseRewardTokenDecimals",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_chefV2",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "getRewardMultipliers",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRewardTokens",
+    "outputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rewardAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "onReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rewardAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "pendingTokens",
+    "outputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rewardAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "pendingTokensDebt",
+    "outputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "rewardMultipliers",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "rewardTokens",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/api/stats/avax/getPangolinV2DualApys.js
+++ b/src/api/stats/avax/getPangolinV2DualApys.js
@@ -44,20 +44,20 @@ const getPangolinV2DualApys = async () => {
     const relativeRewards = rewardPerSecond.times(allocPoints[i]).dividedBy(totalAllocPoint);
     const yearlyRewards = relativeRewards.times(secondsPerYear);
     const yearlyRewardsAInUsd = yearlyRewards.times(tokenPriceA).dividedBy(DECIMALSA);
-    var yearlyRewardsBInUsd = new BigNumber(0);
-    var yearlyRewardsCInUsd = new BigNumber(0);
+    let yearlyRewardsBInUsd = new BigNumber(0);
+    let yearlyRewardsCInUsd = new BigNumber(0);
 
     if (multipliers[i][0] != null) {
+      let multiplier = multipliers[i][0];
       const tokenPriceB = await fetchPrice({ oracle: pool.oracleB, id: pool.oracleIdB });
-      const tokenBMultiplier = multipliers[i].map(v => v.multiplier[0]);
-      const yearlyRewardsB = yearlyRewards.times(tokenBMultiplier).dividedBy(pool.decimalsB);
+      const yearlyRewardsB = yearlyRewards.times(multiplier).dividedBy(DECIMALSA);
       yearlyRewardsBInUsd = yearlyRewardsB.times(tokenPriceB).dividedBy(pool.decimalsB);
     }
     if (multipliers[i][1] != null) {
-      const tokenPriceB = await fetchPrice({ oracle: pool.oracleB, id: pool.oracleIdC });
-      const tokenBMultiplier = multipliers[i][1];
-      const yearlyRewardsB = yearlyRewards.times(tokenBMultiplier).dividedBy(pool.decimalsC);
-      yearlyRewardsCInUsd = yearlyRewardsB.times(tokenPriceB).dividedBy(pool.decimalsB);
+      let multiplier = multipliers[i][1];
+      const tokenPriceC = await fetchPrice({ oracle: pool.oracleB, id: pool.oracleIdC });
+      const yearlyRewardsC = yearlyRewards.times(multiplier).dividedBy(DECIMALSA);
+      yearlyRewardsCInUsd = yearlyRewardsC.times(tokenPriceC).dividedBy(pool.decimalsC);
     }
 
     const yearlyRewardsInUsd = yearlyRewardsAInUsd
@@ -148,7 +148,9 @@ const getPoolsData = async pools => {
     });
   });
 
-  const multipliers = await multicall.all([multipliersCalls]);
+  const multipliers = (await multicall.all([multipliersCalls]))[0].map(m =>
+    m.multiplier.map(v => new BigNumber(v))
+  );
 
   return { balances, allocPoints, multipliers };
 };

--- a/src/api/stats/avax/getPangolinV2DualApys.js
+++ b/src/api/stats/avax/getPangolinV2DualApys.js
@@ -1,0 +1,140 @@
+const BigNumber = require('bignumber.js');
+const { MultiCall } = require('eth-multicall');
+const { avaxWeb3: web3, multicallAddress } = require('../../../utils/web3');
+
+const MasterChef = require('../../../abis/avax/PangolinChef.json');
+const SimpleRewarder = require('../../../abis/avax/SimpleRewarderPerSec.json');
+const ERC20 = require('../../../abis/ERC20.json');
+const fetchPrice = require('../../../utils/fetchPrice');
+const pools = require('../../../data/avax/pangolinV2DualLpPools.json');
+const { BASE_HPY, AVAX_CHAIN_ID } = require('../../../constants');
+const { getTradingFeeAprSushi } = require('../../../utils/getTradingFeeApr');
+import { getFarmWithTradingFeesApy } from '../../../utils/getFarmWithTradingFeesApy';
+const { pangolinClient } = require('../../../apollo/client');
+const { compound } = require('../../../utils/compound');
+
+const masterchef = '0x1f806f7C8dED893fd3caE279191ad7Aa3798E928';
+const oracleIdA = 'PNG';
+const oracleA = 'tokens';
+const DECIMALSA = '1e18';
+
+const secondsPerBlock = 1;
+const secondsPerYear = 31536000;
+
+const liquidityProviderFee = 0.0025;
+const beefyPerformanceFee = 0.045;
+const shareAfterBeefyPerformanceFee = 1 - beefyPerformanceFee;
+
+const getPangolinV2DualApys = async () => {
+  let apys = {};
+  let apyBreakdowns = {};
+
+  const tokenPriceA = await fetchPrice({ oracle: oracleA, id: oracleIdA });
+  const { rewardPerSecond, totalAllocPoint } = await getMasterChefData();
+  const { balances, allocPoints, rewarders } = await getPoolsData(pools);
+
+  const pairAddresses = pools.map(pool => pool.address);
+  const tradingAprs = await getTradingFeeAprSushi(
+    pangolinClient,
+    pairAddresses,
+    liquidityProviderFee
+  );
+
+  for (let i = 0; i < pools.length; i++) {
+    const pool = pools[i];
+
+    const lpPrice = await fetchPrice({ oracle: 'lps', id: pool.name });
+    const totalStakedInUsd = balances[i].times(lpPrice).dividedBy('1e18');
+
+    const poolBlockRewards = rewardPerSecond.times(allocPoints[i]).dividedBy(totalAllocPoint);
+    const yearlyRewards = poolBlockRewards.dividedBy(secondsPerBlock).times(secondsPerYear);
+    const yearlyRewardsAInUsd = yearlyRewards.times(tokenPriceA).dividedBy(DECIMALSA);
+
+    const yearlyRewardsBInUsd = await (async () => {
+      if (rewarders[i] === '0x0000000000000000000000000000000000000000') {
+        return 0;
+      } else {
+        const tokenPriceB = await fetchPrice({ oracle: pool.oracleB, id: pool.oracleIdB });
+        const rewarderContract = new web3.eth.Contract(SimpleRewarder, rewarders[i]);
+        const tokenBPerSec = new BigNumber(await rewarderContract.methods.tokenPerSec().call());
+        const yearlyRewardsB = tokenBPerSec.dividedBy(secondsPerBlock).times(secondsPerYear);
+        return yearlyRewardsB.times(tokenPriceB).dividedBy(pool.decimalsB);
+      }
+    })();
+
+    const yearlyRewardsInUsd = yearlyRewardsAInUsd.plus(yearlyRewardsBInUsd);
+
+    const simpleApy = yearlyRewardsInUsd.dividedBy(totalStakedInUsd);
+    const vaultApr = simpleApy.times(shareAfterBeefyPerformanceFee);
+    const vaultApy = compound(simpleApy, BASE_HPY, 1, shareAfterBeefyPerformanceFee);
+
+    const tradingApr = tradingAprs[pool.address.toLowerCase()] ?? new BigNumber(0);
+    const totalApy = getFarmWithTradingFeesApy(
+      simpleApy,
+      tradingApr,
+      BASE_HPY,
+      1,
+      shareAfterBeefyPerformanceFee
+    );
+    // console.log(pool.name, simpleApy.valueOf(), tradingApr.valueOf(), apy, totalStakedInUsd.valueOf(), yearlyRewardsInUsd.valueOf());
+
+    // Create reference for legacy /apy
+    const legacyApyValue = { [pool.name]: totalApy };
+
+    apys = { ...apys, ...legacyApyValue };
+
+    // Create reference for breakdown /apy
+    const componentValues = {
+      [pool.name]: {
+        vaultApr: vaultApr.toNumber(),
+        compoundingsPerYear: BASE_HPY,
+        beefyPerformanceFee: beefyPerformanceFee,
+        vaultApy: vaultApy,
+        lpFee: liquidityProviderFee,
+        tradingApr: tradingApr.toNumber(),
+        totalApy: totalApy,
+      },
+    };
+
+    apyBreakdowns = { ...apyBreakdowns, ...componentValues };
+  }
+
+  // Return both objects for later parsing
+  return {
+    apys,
+    apyBreakdowns,
+  };
+};
+
+const getMasterChefData = async () => {
+  const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
+  const rewardPerSecond = new BigNumber(await masterchefContract.methods.rewardPerSecond().call());
+  const totalAllocPoint = new BigNumber(await masterchefContract.methods.totalAllocPoint().call());
+  return { rewardPerSecond, totalAllocPoint };
+};
+
+const getPoolsData = async pools => {
+  const masterchefContract = new web3.eth.Contract(MasterChef, masterchef);
+  const multicall = new MultiCall(web3, multicallAddress(AVAX_CHAIN_ID));
+  const balanceCalls = [];
+  const poolInfoCalls = [];
+  pools.forEach(pool => {
+    const tokenContract = new web3.eth.Contract(ERC20, pool.address);
+    balanceCalls.push({
+      balance: tokenContract.methods.balanceOf(masterchef),
+    });
+    let poolInfo = masterchefContract.methods.poolInfo(pool.poolId);
+    poolInfoCalls.push({
+      poolInfo: poolInfo,
+    });
+  });
+
+  const res = await multicall.all([balanceCalls, poolInfoCalls]);
+
+  const balances = res[0].map(v => new BigNumber(v.balance));
+  const allocPoints = res[1].map(v => v.poolInfo['3']);
+  const rewarders = res[1].map(v => v.poolInfo[4]);
+  return { balances, allocPoints, rewarders };
+};
+
+module.exports = getPangolinV2DualApys;

--- a/src/api/stats/avax/index.js
+++ b/src/api/stats/avax/index.js
@@ -12,6 +12,7 @@ const getSingularApys = require('./getSingularApys');
 const getBlizzLpApys = require('./getBlizzLpApys');
 const getBlizzLendingApys = require('./getBlizzLendingApys');
 const getBankerJoeApys = require('./getBankerJoeApys');
+const getPangolinV2DualApys = require('./getPangolinV2DualApys');
 import { getSynapseApys } from './getSynapseApys';
 
 const getSpellApys = require('./getSpellApys');
@@ -21,6 +22,7 @@ import { getPangolinV2Apys } from './getPangolinV2Apys';
 
 const getApys = [
   getPangolinV2Apys,
+  getPangolinV2DualApys,
   getLydLpApys,
   getPangolinPNGApy,
   getOliveApys,

--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -195,6 +195,7 @@ import fusefiPools from '../../data/fuse/fusefiLpPools.json';
 import netswapPools from '../../data/metis/netswapLpPools.json';
 import dibsLpPools from '../../data/degens/dibsLpPools.json';
 import pangolinV2Pools from '../../data/avax/pangolinv2LpPools.json';
+import pangolinV2DualPools from '../../data/avax/pangolinV2DualLpPools.json';
 import t2ombLpPools from '../../data/fantom/2ombLpPools.json';
 import tethysPools from '../../data/metis/tethysLpPools.json';
 import popsicleMaticPools from '../../data/matic/popsicleLpPools.json';
@@ -214,6 +215,7 @@ const pools = [
   ...tethysPools,
   ...t2ombLpPools,
   ...pangolinV2Pools,
+  ...pangolinV2DualPools,
   ...dibsLpPools,
   ...netswapPools,
   ...fusefiPools,

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,6 @@ app.context.cache = {};
 app.use(router.routes());
 app.use(router.allowedMethods());
 
-const port = process.env.PORT || 3001;
+const port = process.env.PORT || 3000;
 app.listen(port);
 console.log(`> beefy-api running! (:${port})`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,6 @@ app.context.cache = {};
 app.use(router.routes());
 app.use(router.allowedMethods());
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 3001;
 app.listen(port);
 console.log(`> beefy-api running! (:${port})`);

--- a/src/data/avax/pangolinV2DualLpPools.json
+++ b/src/data/avax/pangolinV2DualLpPools.json
@@ -1,5 +1,53 @@
 [
   {
+    "name": "png-ust-wavax",
+    "address": "0xdeaBb6e80141F5E557EcBDD7e9580F37D7BBc371",
+    "decimals": "1e18",
+    "poolId": 74,
+    "chainId": 43114,
+    "oracleB": "tokens",
+    "oracleIdB": "LUNA",
+    "decimalsB": "1e6",
+    "oracleIdC": "AVAX",
+    "decimalsC": "1e18",
+    "lp0": {
+      "address": "0x260Bbf5698121EB85e7a74f2E45E16Ce762EbE11",
+      "oracle": "tokens",
+      "oracleId": "UST",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      "oracle": "tokens",
+      "oracleId": "AVAX",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "png-ust-usdc",
+    "address": "0x3c0ECf5F430bbE6B16A8911CB25d898Ef20805cF",
+    "decimals": "1e18",
+    "poolId": 75,
+    "chainId": 43114,
+    "oracleB": "tokens",
+    "oracleIdB": "LUNA",
+    "decimalsB": "1e6",
+    "oracleIdC": "AVAX",
+    "decimalsC": "1e18",
+    "lp0": {
+      "address": "0x260Bbf5698121EB85e7a74f2E45E16Ce762EbE11",
+      "oracle": "tokens",
+      "oracleId": "UST",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    }
+  },
+  {
     "name": "png-loot-wavax",
     "address": "0x1bFae75b28925BF4a5bf830c141EA29CB0A868F1",
     "decimals": "1e18",

--- a/src/data/avax/pangolinV2DualLpPools.json
+++ b/src/data/avax/pangolinV2DualLpPools.json
@@ -17,7 +17,7 @@
     "lp1": {
       "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
       "oracle": "tokens",
-      "oracleId": "WAVAX",
+      "oracleId": "AVAX",
       "decimals": "1e18"
     }
   }

--- a/src/data/avax/pangolinV2DualLpPools.json
+++ b/src/data/avax/pangolinV2DualLpPools.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "png-loot-wavax",
+    "address": "0x1bFae75b28925BF4a5bf830c141EA29CB0A868F1",
+    "decimals": "1e18",
+    "poolId": 65,
+    "chainId": 43114,
+    "oracleB": "tokens",
+    "oracleIdB": "LOOT",
+    "decimalsB": "1e18",
+    "lp0": {
+      "address": "0x7f041ce89A2079873693207653b24C15B5e6A293",
+      "oracle": "tokens",
+      "oracleId": "LOOT",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      "oracle": "tokens",
+      "oracleId": "WAVAX",
+      "decimals": "1e18"
+    }
+  }
+]


### PR DESCRIPTION
I implemented an apy calculation for dual reward farms on Pangolin.

The first pool to use this script will be LOOT-AVAX (PNG + LOOT rewards)
Want: 0x1bFae75b28925BF4a5bf830c141EA29CB0A868F1
PoolId: 65

Any further dual reward farms such as the upcoming UST pools can simply be added to the PangolinV2DualLpPools.json.

Implementation details:
The yearlyRewardsB are calculated by multiplying the yearlyRewardsA(PNG rewards, 18 dec) with the multiplier(divided by 1e18) provided by the rewarder contract.