### PR TITLE
Add Voltage FUSE-UST + LUNA-UST + renaming of FuseFi to Voltage

### DIFF
--- a/packages/address-book/address-book/fuse/tokens/tokens.ts
+++ b/packages/address-book/address-book/fuse/tokens/tokens.ts
@@ -39,6 +39,17 @@ const _tokens = {
     website: 'https://weth.io/',
     description: 'Ether or ETH is the native currency built on the Ethereum blockchain.',
   },
+  atUST: {
+    name: 'UST Terra',
+    symbol: 'atUST',
+    address: '0x0D58a44be3dCA0aB449965dcc2c46932547Fea2f',
+    chainId: 122,
+    decimals: 18,
+    logoURI: '',
+    website: 'https://www.terra.money/',
+    description:
+      'Terra is a public blockchain protocol deploying a suite of algorithmic decentralized stablecoins which underpin a thriving ecosystem that brings DeFi to the masses.',
+  },
   WBTC: {
     name: 'Wrapped BTC on Fuse',
     symbol: 'WBTC',

--- a/packages/address-book/address-book/fuse/tokens/tokens.ts
+++ b/packages/address-book/address-book/fuse/tokens/tokens.ts
@@ -29,16 +29,6 @@ const _tokens = {
     logoURI:
       'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/images/single-assets/BIFI.png',
   },
-  WETH: {
-    name: 'Wrapped Ether on Fuse',
-    symbol: 'WETH',
-    address: '0xa722c13135930332Eb3d749B2F0906559D2C5b99',
-    chainId: 122,
-    decimals: 18,
-    logoURI: '',
-    website: 'https://weth.io/',
-    description: 'Ether or ETH is the native currency built on the Ethereum blockchain.',
-  },
   atUST: {
     name: 'UST Terra',
     symbol: 'atUST',
@@ -49,6 +39,27 @@ const _tokens = {
     website: 'https://www.terra.money/',
     description:
       'Terra is a public blockchain protocol deploying a suite of algorithmic decentralized stablecoins which underpin a thriving ecosystem that brings DeFi to the masses.',
+  },
+  atLUNA: {
+    name: 'Luna Terra',
+    symbol: 'atUST',
+    address: '0x588e24DEd8f850b14BB2e62E9c50A7Cd5Ee13Da9',
+    chainId: 122,
+    decimals: 18,
+    logoURI: '',
+    website: 'https://www.terra.money/',
+    description:
+      'The Terra protocols native staking token that absorbs the price volatility of Terra. Luna is used for governance and in mining. Users stake Luna to validators who record and verify transactions on the blockchain in exchange for rewards from transaction fees. The more Terra is used, the more Luna is worth.',
+  },
+  WETH: {
+    name: 'Wrapped Ether on Fuse',
+    symbol: 'WETH',
+    address: '0xa722c13135930332Eb3d749B2F0906559D2C5b99',
+    chainId: 122,
+    decimals: 18,
+    logoURI: '',
+    website: 'https://weth.io/',
+    description: 'Ether or ETH is the native currency built on the Ethereum blockchain.',
   },
   WBTC: {
     name: 'Wrapped BTC on Fuse',

--- a/src/data/fuse/fusefiLpPools.json
+++ b/src/data/fuse/fusefiLpPools.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "voltage-luna-ust",
+    "address": "0x44cB3a602AE57b60A5dc808a44544Ab9ec8dDB36",
+    "rewardPool": "0xE25d7A32903e29F5909d461cD89729aF6f2c9399",
+    "decimals": "1e18",
+    "chainId": 122,
+    "lp0": {
+      "address": "0x0D58a44be3dCA0aB449965dcc2c46932547Fea2f",
+      "oracle": "tokens",
+      "oracleId": "atUST",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x588e24DEd8f850b14BB2e62E9c50A7Cd5Ee13Da9",
+      "oracle": "tokens",
+      "oracleId": "atLUNA",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "voltage-wfuse-ust",
     "address": "0x53B1B8Fb8bE9aA94076e6B29fb9D08bd9ced2D30",
     "rewardPool": "0xe39c87605FeE81b509034E408EC2D2cE592E8B33",

--- a/src/data/fuse/fusefiLpPools.json
+++ b/src/data/fuse/fusefiLpPools.json
@@ -1,6 +1,25 @@
 [
   {
-    "name": "fusefi-wfuse-g$",
+    "name": "voltage-wfuse-ust",
+    "address": "0x53B1B8Fb8bE9aA94076e6B29fb9D08bd9ced2D30",
+    "rewardPool": "0xe39c87605FeE81b509034E408EC2D2cE592E8B33",
+    "decimals": "1e18",
+    "chainId": 122,
+    "lp0": {
+      "address": "0x0BE9e53fd7EDaC9F859882AfdDa116645287C629",
+      "oracle": "tokens",
+      "oracleId": "WFUSE",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x0D58a44be3dCA0aB449965dcc2c46932547Fea2f",
+      "oracle": "tokens",
+      "oracleId": "atUST",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "voltage-wfuse-g$",
     "address": "0x8d441C2Ff54C015A1BE22ad88e5D42EFBEC6C7EF",
     "rewardPool": "0xa7fa94cDA70753be12BBf94A46417e9B4AdB553f",
     "decimals": "1e18",
@@ -19,7 +38,7 @@
     }
   },
   {
-    "name": "fusefi-wfuse-busd",
+    "name": "voltage-wfuse-busd",
     "address": "0x2e7DeDEfC1b40eb2C935A5d07ACDb8F8a9B2A91D",
     "rewardPool": "0x39ce2B1f8e73Ae1FE4eb3aeCC0D68B8855bb24F7",
     "decimals": "1e18",
@@ -38,7 +57,7 @@
     }
   },
   {
-    "name": "fusefi-fusd-bnb",
+    "name": "voltage-fusd-bnb",
     "address": "0x123e18262642a090b209A9CdD5bC5DFA03d734D1",
     "rewardPool": "0x1E3C4727A7dAFDd51Dc202232D2eB696E734f1Cb",
     "decimals": "1e18",
@@ -57,7 +76,7 @@
     }
   },
   {
-    "name": "fusefi-wfuse-fusd",
+    "name": "voltage-wfuse-fusd",
     "address": "0xcDd8964BA8963929867CAfFCf5942De4F085bFB7",
     "rewardPool": "0x076BDeA1fD4695BDEF9Ba4579463BC4B3C97d645",
     "decimals": "1e18",
@@ -76,7 +95,7 @@
     }
   },
   {
-    "name": "fusefi-wbtc-weth",
+    "name": "voltage-wbtc-weth",
     "address": "0x79FB917292f841Ab64941C04aCDf5F9059aa24E7",
     "rewardPool": "0x45609C92B46F8f9d101D421f155eD558a043AF99",
     "decimals": "1e18",
@@ -95,7 +114,7 @@
     }
   },
   {
-    "name": "fusefi-wfuse-weth",
+    "name": "voltage-wfuse-weth",
     "address": "0x75e24462108E49B71278c93b49B35A5837c0547C",
     "rewardPool": "0xbCa51ae3896f4033fb7B467BD3ab4A4ff27f3a3E",
     "decimals": "1e18",
@@ -114,7 +133,7 @@
     }
   },
   {
-    "name": "fusefi-wfuse-usdc",
+    "name": "voltage-wfuse-usdc",
     "address": "0x9f17b1895633E855b8b1C1D0Ade9B3B72EB0590C",
     "rewardPool": "0x38D4e6Df715b968B49579F64eCA15B12FB972884",
     "decimals": "1e18",


### PR DESCRIPTION
Added the new wfuse-ust pool (Voltage, ex. FuseFi).
I also renamed the oracle ids of the existing voltage pools. The id's within the app will be adapted in a complementary pull request on the beefy-app.

If you want even deeper renaming including all the file names and other variables regarding FuseFi, please let me know. For now, I didn't want to interfere too much with the existing base.

