### PR TITLE
Add BNB-USDC, BOOK-MATIC, FODL-MATIC, QUICK-TEL (Polygon)

### DIFF
--- a/packages/address-book/address-book/polygon/tokens/tokens.ts
+++ b/packages/address-book/address-book/polygon/tokens/tokens.ts
@@ -27,6 +27,28 @@ const MAI = {
 } as const;
 
 const _tokens = {
+  BOOK: {
+    name: 'Bookie Dao BOOK',
+    symbol: 'BOOK',
+    address: '0x8192759Bf7f247cC92F74E39B3A4225516624fC1',
+    chainId: 137,
+    decimals: 8,
+    logoURI: 'https://bookie.farm/logoether/bookie200.png',
+    website: 'https://bookie.farm/',
+    description:
+      'Decentralized Betting, where Odds & Games meet the Bookie - play the game or be the house, your stake!',
+  },
+  FODL: {
+    name: 'Fodl Finance FODL',
+    symbol: 'FODL',
+    address: '0x5314bA045a459f63906Aa7C76d9F337DcB7d6995',
+    chainId: 137,
+    decimals: 18,
+    logoURI: 'https://assets.coingecko.com/coins/images/19040/large/new.jpg?1634559024',
+    website: 'https://fodl.finance/',
+    description:
+      'Fodl enables traders to utilize leverage for their trades without paying a funding rate. This leverage is derived from existing DeFi building blocks, such as Compound and Aave.',
+  },
   SAND: {
     name: 'Sandbox',
     symbol: 'SAND',

--- a/src/api/stats/common/getRewardPoolDualApys.ts
+++ b/src/api/stats/common/getRewardPoolDualApys.ts
@@ -131,12 +131,21 @@ const getPoolsData = async (params: DualRewardPoolParams) => {
     balanceCalls.push({
       balance: rewardPool.methods.totalSupply(),
     });
-    rewardRateACalls.push({
-      rewardRateA: rewardPool.methods.rewardRateA(),
-    });
-    rewardRateBCalls.push({
-      rewardRateB: rewardPool.methods.rewardRateB(),
-    });
+    if (pool.name == 'quick-quick-tel') {
+      rewardRateACalls.push({
+        rewardRateA: rewardPool.methods.rewardRateB(),
+      });
+      rewardRateBCalls.push({
+        rewardRateB: rewardPool.methods.rewardRateA(),
+      });
+    } else {
+      rewardRateACalls.push({
+        rewardRateA: rewardPool.methods.rewardRateA(),
+      });
+      rewardRateBCalls.push({
+        rewardRateB: rewardPool.methods.rewardRateB(),
+      });
+    }
   });
 
   const res = await multicall.all([balanceCalls, rewardRateACalls, rewardRateBCalls]);

--- a/src/data/matic/quickDualLpPools.json
+++ b/src/data/matic/quickDualLpPools.json
@@ -1,5 +1,77 @@
 [
   {
+    "name": "quick-quick-tel",
+    "address": "0xE88e24F49338f974B528AcE10350Ac4576c5c8A1",
+    "rewardPool": "0xF8bdC7bC282847EeB5d4291ec79172B48526e9dE",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x831753DD7087CaC61aB5644b308642cc1c33Dc13",
+      "oracle": "tokens",
+      "oracleId": "QUICK",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32",
+      "oracle": "tokens",
+      "oracleId": "TEL",
+      "decimals": "1e2"
+    },
+    "rewardB": {
+      "oracle": "tokens",
+      "oracleId": "TEL",
+      "decimals": "1e2"
+    }
+  },
+  {
+    "name": "quick-fodl-matic",
+    "address": "0x2Fc4DFCEe8C331D54341f5668a6d9BCdd86F8e2f",
+    "rewardPool": "0x75CA5C33ed96222ddE8488C385E823852161d44a",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+      "oracle": "tokens",
+      "oracleId": "MATIC",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x5314bA045a459f63906Aa7C76d9F337DcB7d6995",
+      "oracle": "tokens",
+      "oracleId": "FODL",
+      "decimals": "1e18"
+    },
+    "rewardB": {
+      "oracle": "tokens",
+      "oracleId": "FODL",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "quick-book-matic",
+    "address": "0xE6672538c35508b011b82C986B8822ECF26b1cbC",
+    "rewardPool": "0xd1E4545adeDBa83Ee85768612b0f1cdC6D69C493",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+      "oracle": "tokens",
+      "oracleId": "MATIC",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x8192759Bf7f247cC92F74E39B3A4225516624fC1",
+      "oracle": "tokens",
+      "oracleId": "BOOK",
+      "decimals": "1e8"
+    },
+    "rewardB": {
+      "oracle": "tokens",
+      "oracleId": "BOOK",
+      "decimals": "1e8"
+    }
+  },
+  {
     "name": "quick-psp-matic",
     "address": "0x7AfC060acCA7ec6985d982dD85cC62B111CAc7a7",
     "rewardPool": "0x64D2B3994F64E3E82E48CC92e1122489e88e8727",

--- a/src/data/matic/quickLpPools.json
+++ b/src/data/matic/quickLpPools.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "quick-bnb-usdc",
+    "address": "0x40A5Df3E37152d4DaF279e0450289Af76472b02e",
+    "rewardPool": "0xCd7E62D9E2D209EcB22EC48A942b4db9503aB97B",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0x5c4b7CCBF908E64F32e12c6650ec0C96d717f03F",
+      "oracle": "tokens",
+      "oracleId": "BNB",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "quick-sand-matic",
     "address": "0x369582d2010B6eD950B571F4101e3bB9b554876F",
     "rewardPool": "0x411b772B9eb19a33E7af5fCD9B1629D2015DC886",


### PR DESCRIPTION
BNB-USDC
Want: 0x40A5Df3E37152d4DaF279e0450289Af76472b02e
RewardPool: 0xCd7E62D9E2D209EcB22EC48A942b4db9503aB97B 

BOOK-MATIC
Want: 0xE6672538c35508b011b82C986B8822ECF26b1cbC
RewardPool: 0xd1E4545adeDBa83Ee85768612b0f1cdC6D69C493

FODL-MATIC
Want: 0x2Fc4DFCEe8C331D54341f5668a6d9BCdd86F8e2f
RewardPool: 0x75CA5C33ed96222ddE8488C385E823852161d44a

QUICK-TEL
Want: 0xE88e24F49338f974B528AcE10350Ac4576c5c8A1
RewardPool: 0xF8bdC7bC282847EeB5d4291ec79172B48526e9dE 

For the QUICK-TEL pool, I had to adapt the getRewardPoolDualApys script, as the rewarder contract for this pool is the only one where dQuick is not rewardA, but rewardB. (see https://polygonscan.com/address/0xf8bdc7bc282847eeb5d4291ec79172b48526e9de#readContract)
The script getRewardPoolDualApys is only used in getQuickDualLpApys, so although the if-clause is a bit ugly, there's no major performance impact, as this script only handles a handful of pools.