### PR TITLE
Add Tethys mUSDC-mUSDT Pool

### DIFF
--- a/src/data/metis/tethysLpPools.json
+++ b/src/data/metis/tethysLpPools.json
@@ -93,5 +93,24 @@
       "oracleId": "METIS",
       "decimals": "1e18"
     }
+  },
+  {
+    "name": "tethys-m.usdc-m.usdt",
+    "address": "0x6c4768d4b3acD4a3fF01F179FaffDaEbe084D12D",
+    "decimals": "1e18",
+    "poolId": 5,
+    "chainId": 1088,
+    "lp0": {
+      "address": "0xbB06DCA3AE6887fAbF931640f67cab3e3a16F4dC",
+      "oracle": "tokens",
+      "oracleId": "USDT",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0xEA32A96608495e54156Ae48931A7c20f0dcc1a21",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    }
   }
 ]


### PR DESCRIPTION
Adding the new m.USDC-m.USDT pool on Tethys Finance (Metis) to the API

Vault: [0xc674cf138415244041d512Edf1c7943D99dD229F](https://andromeda-explorer.metis.io/address/0xc674cf138415244041d512Edf1c7943D99dD229F)
Strategy: [0x481a546dc0beb4d4C63Fd7cEE63053eE6D73EdDb](https://andromeda-explorer.metis.io/address/0x481a546dc0beb4d4C63Fd7cEE63053eE6D73EdDb)
Want: 0x6c4768d4b3acd4a3ff01f179faffdaebe084d12d
PoolId: 5