### PR TITLE
Add token JRT-ETH-KPI

### DIFF
--- a/src/data/matic/kyberLpPools.json
+++ b/src/data/matic/kyberLpPools.json
@@ -74,5 +74,24 @@
       "oracleId": "AUR",
       "decimals": "1e18"
     }
+  },
+  {
+    "name": "kyber-usdc-jrt-eth-kpi",
+    "address": "0x32461FCAB98A34C3F1Ad362dCEC6D290a0be1005",
+    "decimals": "1e18",
+    "poolId": 3,
+    "chainId": 137,
+    "lp0": {
+      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0x37c2a140bd1de90d195d7ce3587faba7963879fb",
+      "oracle": "tokens",
+      "oracleId": "JRT-ETH-KPI",
+      "decimals": "1e18"
+    }
   }
 ]


### PR DESCRIPTION
Current boost giving out JRT-ETH-KPI is taking price from JRT token giving a wrong apy. Partner has complained about it. Add tracking for correct token