### PR TITLE
Add multiple pools on fantom and fuse

### DIFF
--- a/packages/address-book/address-book/fantom/tokens/tokens.ts
+++ b/packages/address-book/address-book/fantom/tokens/tokens.ts
@@ -38,6 +38,17 @@ const FTM = {
 } as const;
 
 const _tokens = {
+  SHRAP: {
+    name: 'Shrapnel SHRAP',
+    symbol: 'SHRAP',
+    address: '0xbf4906762C38F50bC7Be0A11BB452C944f6C72E1',
+    chainId: 250,
+    decimals: 18,
+    logoURI:
+      'https://app.fbomb.finance/images/tokens/0xbf4906762C38F50bC7Be0A11BB452C944f6C72E1.png',
+    website: 'https://app.fbomb.finance/',
+    description: 'Shrapnel is an inflationary token launched along with BombSwap.',
+  },
   BSHARE: {
     name: 'BSHARE',
     symbol: 'BSHARE',

--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -216,6 +216,7 @@ import solidlyPools from '../../data/fantom/solidlyLpPools.json';
 import solarflare from '../../data/moonbeam/solarFlareLpPools.json';
 import basedPools from '../../data/fantom/basedLpPools.json';
 import voltagePools from '../../data/fuse/voltageLpPools.json';
+import bombSwapPools from '../../data/fantom/bombSwapPools.json';
 
 const INIT_DELAY = 0 * 60 * 1000;
 const REFRESH_INTERVAL = 5 * 60 * 1000;
@@ -223,6 +224,7 @@ const REFRESH_INTERVAL = 5 * 60 * 1000;
 // FIXME: if this list grows too big we might hit the ratelimit on initialization everytime
 // Implement in case of emergency -> https://github.com/beefyfinance/beefy-api/issues/103
 const pools = [
+  ...bombSwapPools,
   ...voltagePools,
   ...basedPools,
   ...stellaswapPools,

--- a/src/data/fantom/basedLpPools.json
+++ b/src/data/fantom/basedLpPools.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "based-based-bshare",
+    "address": "0x5748b5Dd1f59342f85d170c48C427959c2f9f262",
+    "decimals": "1e18",
+    "poolId": 5,
+    "chainId": 250,
+    "lp0": {
+      "address": "0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae",
+      "oracle": "tokens",
+      "oracleId": "BASED",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x49C290Ff692149A4E16611c694fdED42C954ab7a",
+      "oracle": "tokens",
+      "oracleId": "BSHARE",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "based-based-mai",
     "address": "0x7B5B3751550be4FF87aC6bda89533F7A0c9825B3",
     "decimals": "1e18",

--- a/src/data/fantom/beethovenxDualPools.json
+++ b/src/data/fantom/beethovenxDualPools.json
@@ -1,5 +1,51 @@
 [
   {
+    "name": "beets-god-between-stables",
+    "address": "0x8B858Eaf095A7337dE6f9bC212993338773cA34e",
+    "vault": "0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce",
+    "vaultPoolId": "0x8b858eaf095a7337de6f9bc212993338773ca34e00020000000000000000023c",
+    "poolId": 67,
+    "oracleB": "tokens",
+    "oracleIdB": "DEUS",
+    "decimalsB": "1e18",
+    "decimals": "1e18",
+    "tokens": [
+      {
+        "oracle": "tokens",
+        "oracleId": "USDC",
+        "decimals": "1e6"
+      },
+      {
+        "oracle": "tokens",
+        "oracleId": "DEI",
+        "decimals": "1e18"
+      }
+    ]
+  },
+  {
+    "name": "beets-ust-ust",
+    "address": "0x66Bcb58cF9754f421c268990B280e4462E10aac8",
+    "vault": "0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce",
+    "vaultPoolId": "0x66bcb58cf9754f421c268990b280e4462e10aac8000200000000000000000339",
+    "poolId": 66,
+    "oracleB": "tokens",
+    "oracleIdB": "UST",
+    "decimalsB": "1e6",
+    "decimals": "1e18",
+    "tokens": [
+      {
+        "oracle": "tokens",
+        "oracleId": "UST",
+        "decimals": "1e6"
+      },
+      {
+        "oracle": "tokens",
+        "oracleId": "UST",
+        "decimals": "1e6"
+      }
+    ]
+  },
+  {
     "name": "beets-cre8r-f-major",
     "address": "0xbb4607beDE4610e80d35C15692eFcB7807A2d0A6",
     "vault": "0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce",

--- a/src/data/fantom/beethovenxPools.json
+++ b/src/data/fantom/beethovenxPools.json
@@ -1,5 +1,45 @@
 [
   {
+    "name": "beets-boomer-beets",
+    "address": "0x8DBB92ca6c399792AC07510a0996C59902cD75a1",
+    "vault": "0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce",
+    "vaultPoolId": "0x8dbb92ca6c399792ac07510a0996c59902cd75a1000200000000000000000299",
+    "poolId": 62,
+    "decimals": "1e18",
+    "tokens": [
+      {
+        "oracle": "tokens",
+        "oracleId": "BTC",
+        "decimals": "1e8"
+      },
+      {
+        "oracle": "tokens",
+        "oracleId": "BEETS",
+        "decimals": "1e18"
+      }
+    ]
+  },
+  {
+    "name": "beets-exploding-shrapnel",
+    "address": "0x2Ba4953C75860e70Cd70f15a2D5Fe07DE832Bcd1",
+    "vault": "0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce",
+    "vaultPoolId": "0x2ba4953c75860e70cd70f15a2d5fe07de832bcd1000200000000000000000210",
+    "poolId": 50,
+    "decimals": "1e18",
+    "tokens": [
+      {
+        "oracle": "tokens",
+        "oracleId": "WFTM",
+        "decimals": "1e18"
+      },
+      {
+        "oracle": "tokens",
+        "oracleId": "SHRAP",
+        "decimals": "1e18"
+      }
+    ]
+  },
+  {
     "name": "beets-beefy-tale",
     "address": "0x3bd4c3d1f6F40d77B2e9d0007D6f76E4F183A46d",
     "vault": "0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce",

--- a/src/data/fantom/bombSwapPools.json
+++ b/src/data/fantom/bombSwapPools.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "bomb-shrap-ftm",
+    "address": "0xE69b45BE6260634de4e432F66179ce47EE846800",
+    "decimals": "1e18",
+    "poolId": 0,
+    "chainId": 250,
+    "lp0": {
+      "address": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
+      "oracle": "tokens",
+      "oracleId": "WFTM",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xbf4906762C38F50bC7Be0A11BB452C944f6C72E1",
+      "oracle": "tokens",
+      "oracleId": "SHRAP",
+      "decimals": "1e18"
+    }
+  }
+]

--- a/src/data/fuse/voltageLpPools.json
+++ b/src/data/fuse/voltageLpPools.json
@@ -1,5 +1,27 @@
 [
   {
+    "name": "voltagev2-wfuse-ageur",
+    "address": "0xeeD7A28eEd4E768fCD46dE3642AB73488De77e11",
+    "decimals": "1e18",
+    "oracleB": "tokens",
+    "oracleIdB": "FUSE",
+    "decimalsB": "1e18",
+    "poolId": 12,
+    "chainId": 122,
+    "lp0": {
+      "address": "0xeFAeeE334F0Fd1712f9a8cc375f427D9Cdd40d73",
+      "oracle": "tokens",
+      "oracleId": "agEUR",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x0BE9e53fd7EDaC9F859882AfdDa116645287C629",
+      "oracle": "tokens",
+      "oracleId": "WFUSE",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "voltagev2-wfuse-fusd",
     "address": "0x933a10d094592EB3F2a26bCb366472eba8868A66",
     "decimals": "1e18",


### PR DESCRIPTION
The BombSwap pool won't actually be vaulted, but is used to calculate a price for SHRAP.
As the Beethovenx pool price calculation (non-amm) is fed with the calculated token prices from the AMMs, we need to include a UniSwapV2 pool containing SHRAP in getAmmPrices to get a price for SHRAP.

If there are alternatives to solve this, I'm open for suggestions