### PR TITLE
Add TombSwap (Based) TOMB-BASED

### DIFF
--- a/src/data/fantom/basedLpPools.json
+++ b/src/data/fantom/basedLpPools.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "based-tomb-based",
+    "address": "0x172BFaA8991A54ABD0b3EE3d4F8CBDab7046FF79",
+    "decimals": "1e18",
+    "poolId": 7,
+    "chainId": 250,
+    "lp0": {
+      "address": "0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7",
+      "oracle": "tokens",
+      "oracleId": "TOMB",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae",
+      "oracle": "tokens",
+      "oracleId": "BASED",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "based-based-bshare",
     "address": "0x5748b5Dd1f59342f85d170c48C427959c2f9f262",
     "decimals": "1e18",


### PR DESCRIPTION
TombSwap (Based) TOMB-BASED
```
Vault:    0x39E5C480bc28b77D8B5960Abc248A21C0cF4bE30
Strategy: 0x8945130ef1F1429A2B25Dc2976cc51c5B22aF917
Want:     0x172BFaA8991A54ABD0b3EE3d4F8CBDab7046FF79
PoolId:   7
```
Note: This farm uses TombSwap LP, distinct from the existing SpookySwap BASED-TOMB pair.
[beefy-app PR #1122](https://github.com/beefyfinance/beefy-app/pull/1122)