### PR TITLE
Add UST and LUNA pools on fantom

### DIFF
--- a/packages/address-book/address-book/fantom/tokens/tokens.ts
+++ b/packages/address-book/address-book/fantom/tokens/tokens.ts
@@ -422,6 +422,17 @@ const _tokens = {
     logoURI:
       'https://assets.coingecko.com/coins/images/21208/small/vXl4xT-P_400x400.png?1638567924',
   },
+  LUNAw: {
+    name: 'LUNA (Wormhole)',
+    symbol: 'LUNA',
+    address: '0x593AE1d34c8BD7587C11D539E4F42BFf242c82Af',
+    chainId: 250,
+    decimals: 6,
+    website: 'https://www.terra.money/',
+    description:
+      'Terras native token, LUNA, is used to stabilize the price of the protocols stablecoins.',
+    logoURI: 'https://s2.coinmarketcap.com/static/img/coins/64x64/4172.png',
+  },
   UST: {
     name: 'USD Terra (anyswap)',
     symbol: 'UST',
@@ -437,7 +448,18 @@ const _tokens = {
     name: 'TerraUSD (Wormhole)',
     symbol: 'UST',
     address: '0x846e4D51d7E2043C1a87E0Ab7490B93FB940357b',
-    chainId: 137,
+    chainId: 250,
+    decimals: 6,
+    logoURI: 'https://s2.coinmarketcap.com/static/img/coins/64x64/7129.png',
+    website: 'https://coinmarketcap.com/currencies/terrausd-wormhole/',
+    description:
+      'Terra stablecoins offer instant settlements, low fees and seamless cross-border exchange - loved by millions of users and merchants.',
+  },
+  USTaxl: {
+    name: 'TerraUSD (Axelar)',
+    symbol: 'UST',
+    address: '0x2B9d3F168905067D88d93F094C938BACEe02b0cB',
+    chainId: 250,
     decimals: 6,
     logoURI: 'https://s2.coinmarketcap.com/static/img/coins/64x64/7129.png',
     website: 'https://coinmarketcap.com/currencies/terrausd-wormhole/',

--- a/src/api/stats/common/getApyBreakdown.ts
+++ b/src/api/stats/common/getApyBreakdown.ts
@@ -36,7 +36,11 @@ export const getApyBreakdown = (
     const simpleApr = farmAprs[i]?.toNumber();
     const vaultApr = simpleApr * SHARE_AFTER_PERFORMANCE_FEE;
     const vaultApy = compound(simpleApr, BASE_HPY, 1, SHARE_AFTER_PERFORMANCE_FEE);
-    const tradingApr: number | undefined = tradingAprs[pool.address.toLowerCase()]?.toNumber();
+    const tradingApr: number | undefined = (
+      (tradingAprs[pool.address.toLowerCase()] ?? new BigNumber(0)).isFinite()
+        ? tradingAprs[pool.address.toLowerCase()]
+        : new BigNumber(0)
+    )?.toNumber();
     const totalApy = getFarmWithTradingFeesApy(
       simpleApr,
       tradingApr,

--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -463,6 +463,7 @@ const knownPrices = {
   USDN: 1,
   cUSD: 1,
   asUSDC: 1,
+  USTaxl: 1,
 };
 
 let tokenPricesCache: Promise<any>;

--- a/src/data/fantom/beethovenxDualPools.json
+++ b/src/data/fantom/beethovenxDualPools.json
@@ -29,18 +29,18 @@
     "vaultPoolId": "0x66bcb58cf9754f421c268990b280e4462e10aac8000200000000000000000339",
     "poolId": 66,
     "oracleB": "tokens",
-    "oracleIdB": "UST",
+    "oracleIdB": "USTaxl",
     "decimalsB": "1e6",
     "decimals": "1e18",
     "tokens": [
       {
         "oracle": "tokens",
-        "oracleId": "UST",
+        "oracleId": "USTw",
         "decimals": "1e6"
       },
       {
         "oracle": "tokens",
-        "oracleId": "UST",
+        "oracleId": "USTaxl",
         "decimals": "1e6"
       }
     ]

--- a/src/data/fantom/spookyLpPools.json
+++ b/src/data/fantom/spookyLpPools.json
@@ -1,5 +1,43 @@
 [
   {
+    "name": "boo-wftm-luna",
+    "address": "0xD8934C58dE27e7B6342924B185dA0B3AB009F959",
+    "decimals": "1e18",
+    "poolId": 75,
+    "chainId": 250,
+    "lp0": {
+      "address": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
+      "oracle": "tokens",
+      "oracleId": "WFTM",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x593AE1d34c8BD7587C11D539E4F42BFf242c82Af",
+      "oracle": "tokens",
+      "oracleId": "LUNAw",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "boo-wftm-ust",
+    "address": "0x656b3264695690322ACBad95F994b51C5a8C8eDF",
+    "decimals": "1e18",
+    "poolId": 76,
+    "chainId": 250,
+    "lp0": {
+      "address": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
+      "oracle": "tokens",
+      "oracleId": "WFTM",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x846e4D51d7E2043C1a87E0Ab7490B93FB940357b",
+      "oracle": "tokens",
+      "oracleId": "USTw",
+      "decimals": "1e6"
+    }
+  },
+  {
     "name": "boo-stg-usdc",
     "address": "0x0a80C53AfC6DE9dfB2017781436BfE5090F4aCB4",
     "decimals": "1e18",


### PR DESCRIPTION
The UST-UST pool on Beethovenx uses UST (Axelar), which does not have a UniSwapV2 pool on any other fantom dex, therefore I added it to the list of knownPrices.

I also had to create new entries to the address book.
Breakdown of UST and LUNA addresses in the fantom AB:
LUNA -> Multichain(Anyswap)
LUNAw -> Wormhole
UST -> Multichain
USTw -> Wormhole
USTaxl -> Axelar

With the UST-UST pool on Beets, there is an issue with the subgraph not returning any 'totalLiquidity'. Therefore the tradingApr will be 'infinity'.
I had to adapt the getApyBreakdown script to map 'infinity' values to 0.

![beets_ust_ust](https://user-images.githubusercontent.com/39047198/162571161-c64ab8a0-ecc8-49b3-9344-32e54f670941.png)