### PR TITLE
Clean up AVAX USDT tokens

### DIFF
--- a/packages/address-book/address-book/avax/tokens/tokens.ts
+++ b/packages/address-book/address-book/avax/tokens/tokens.ts
@@ -3436,26 +3436,26 @@ const _tokens = {
     logoURI:
       'https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0xbE53F019a8786227E3D258A47a0D96BCf24A09A6/logo.png',
   },
-  USDt: {
+  USDT: {
     chainId: 43114,
     address: '0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7',
     decimals: 6,
-    name: 'Tether USD',
-    symbol: 'USDt',
+    name: 'Tether USD (native)',
+    symbol: 'USDT',
     website: 'https://tether.to/',
     description:
       'Tether is a stablecoin pegged to the US Dollar. A stablecoin is a type of cryptocurrency whose value is pegged to another fiat currency like the US Dollar or to a commodity like Gold.Tether is the first stablecoin to be created and it is the most popular stablecoin used in the ecosystem.',
     logoURI: 'https://snowtrace.io/token/images/tether_32.png',
   },
-  USDT: {
+  USDTo: {
     chainId: 43114,
     address: '0xde3A24028580884448a5397872046a019649b084',
     decimals: 6,
-    name: 'Tether USD',
-    symbol: 'USDT',
+    name: 'Tether USD (bridged)',
+    symbol: 'USDTo',
     website: 'https://tether.to/',
     description:
-      'Tether is a stablecoin pegged to the US Dollar. A stablecoin is a type of cryptocurrency whose value is pegged to another fiat currency like the US Dollar or to a commodity like Gold.Tether is the first stablecoin to be created and it is the most popular stablecoin used in the ecosystem.',
+      'Tether is a stablecoin pegged to the US Dollar. A stablecoin is a type of cryptocurrency whose value is pegged to another fiat currency like the US Dollar or to a commodity like Gold.Tether is the first stablecoin to be created and it is the most popular stablecoin used in the ecosystem. From Avalanche Bridge.',
     logoURI:
       'https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0xde3A24028580884448a5397872046a019649b084/logo.png',
   },
@@ -4230,23 +4230,11 @@ const _tokens = {
     chainId: 43114,
     address: '0xc7198437980c041c805A1EDcbA50c1Ce5db95118',
     decimals: 6,
-    name: 'Tether USD',
-    symbol: 'USDT',
+    name: 'Tether USD (eth bridged)',
+    symbol: 'USDTe',
     website: 'https://tether.to/',
     description:
-      'Tether is a stablecoin pegged to the US Dollar. A stablecoin is a type of cryptocurrency whose value is pegged to another fiat currency like the US Dollar or to a commodity like Gold.Tether is the first stablecoin to be created and it is the most popular stablecoin used in the ecosystem.',
-    logoURI:
-      'https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0xde3A24028580884448a5397872046a019649b084/logo.png',
-  },
-  'USDT-Tether USD': {
-    chainId: 43114,
-    address: '0xde3A24028580884448a5397872046a019649b084',
-    decimals: 6,
-    name: 'Tether USD',
-    symbol: 'USDT',
-    website: 'https://tether.to/',
-    description:
-      'Tether is a stablecoin pegged to the US Dollar. A stablecoin is a type of cryptocurrency whose value is pegged to another fiat currency like the US Dollar or to a commodity like Gold.Tether is the first stablecoin to be created and it is the most popular stablecoin used in the ecosystem.',
+      'Tether is a stablecoin pegged to the US Dollar. A stablecoin is a type of cryptocurrency whose value is pegged to another fiat currency like the US Dollar or to a commodity like Gold.Tether is the first stablecoin to be created and it is the most popular stablecoin used in the ecosystem.  This version is bridged from Ethereum.',
     logoURI:
       'https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0xde3A24028580884448a5397872046a019649b084/logo.png',
   },

--- a/src/data/avax/blizzPools.json
+++ b/src/data/avax/blizzPools.json
@@ -44,17 +44,6 @@
     "borrowPercent": 0.01
   },
   {
-    "name": "blizz-usdt-supply",
-    "token": "0xc7198437980c041c805A1EDcbA50c1Ce5db95118",
-    "aToken": "0x18cb11C9F2B6F45A7ac0A95eFD322ED4cf9EEEBF",
-    "debtToken": "0xE928AC9837e703f5d36066De9ca98e95bA7774d1",
-    "oracle": "tokens",
-    "oracleId": "USDT.e",
-    "decimals": "1e6",
-    "borrowDepth": 1,
-    "borrowPercent": 0.01
-  },
-  {
     "name": "blizz-usdc-supply",
     "token": "0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664",
     "aToken": "0xC25Ff1aF397b76252D6975b4D7649b35C0E60F69",
@@ -108,17 +97,6 @@
     "decimals": "1e18",
     "borrowDepth": 4,
     "borrowPercent": 0.72
-  },
-  {
-    "name": "blizz-usdt",
-    "token": "0xc7198437980c041c805A1EDcbA50c1Ce5db95118",
-    "aToken": "0x18cb11C9F2B6F45A7ac0A95eFD322ED4cf9EEEBF",
-    "debtToken": "0xE928AC9837e703f5d36066De9ca98e95bA7774d1",
-    "oracle": "tokens",
-    "oracleId": "USDT.e",
-    "decimals": "1e6",
-    "borrowDepth": 4,
-    "borrowPercent": 0.77
   },
   {
     "name": "blizz-usdc",

--- a/src/data/avax/comAvaxLpPools.json
+++ b/src/data/avax/comAvaxLpPools.json
@@ -71,7 +71,7 @@
     "lp1": {
       "address": "0xde3A24028580884448a5397872046a019649b084",
       "oracle": "tokens",
-      "oracleId": "USDT",
+      "oracleId": "USDTo",
       "decimals": "1e6"
     }
   },

--- a/src/data/avax/joeBoostedLpPools.json
+++ b/src/data/avax/joeBoostedLpPools.json
@@ -8,7 +8,7 @@
     "lp0": {
       "address": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
       "oracle": "tokens",
-      "oracleId": "USDt",
+      "oracleId": "USDT",
       "decimals": "1e6"
     },
     "lp1": {

--- a/src/data/avax/joeLpPools.json
+++ b/src/data/avax/joeLpPools.json
@@ -361,25 +361,6 @@
     }
   },
   {
-    "name": "joe-link.e-usdt.e",
-    "address": "0x59E4e5501764a293B829902D9CF01967FA80eff2",
-    "decimals": "1e18",
-    "poolId": 34,
-    "chainId": 43114,
-    "lp0": {
-      "address": "0x5947BB275c521040051D82396192181b413227A3",
-      "oracle": "tokens",
-      "oracleId": "LINK.e",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xc7198437980c041c805A1EDcbA50c1Ce5db95118",
-      "oracle": "tokens",
-      "oracleId": "USDT.e",
-      "decimals": "1e6"
-    }
-  },
-  {
     "name": "joe-link.e-usdc.e",
     "address": "0xb9f425bC9AF072a91c423e31e9eb7e04F226B39D",
     "decimals": "1e18",
@@ -395,25 +376,6 @@
       "address": "0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664",
       "oracle": "tokens",
       "oracleId": "USDC.e",
-      "decimals": "1e6"
-    }
-  },
-  {
-    "name": "joe-weth.e-usdt.e",
-    "address": "0xbe1b87f47fDE3F338Aa3AA98b85435e1709dFD06",
-    "decimals": "1e18",
-    "poolId": 33,
-    "chainId": 43114,
-    "lp0": {
-      "address": "0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB",
-      "oracle": "tokens",
-      "oracleId": "WETH.e",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xc7198437980c041c805A1EDcbA50c1Ce5db95118",
-      "oracle": "tokens",
-      "oracleId": "USDT.e",
       "decimals": "1e6"
     }
   },

--- a/src/data/avax/lydLpPools.json
+++ b/src/data/avax/lydLpPools.json
@@ -33,7 +33,7 @@
     "lp1": {
       "address": "0xde3A24028580884448a5397872046a019649b084",
       "oracle": "tokens",
-      "oracleId": "USDT",
+      "oracleId": "USDTo",
       "decimals": "1e6"
     }
   }

--- a/src/data/avax/oliveLpPools.json
+++ b/src/data/avax/oliveLpPools.json
@@ -52,7 +52,7 @@
     "lp1": {
       "address": "0xde3A24028580884448a5397872046a019649b084",
       "oracle": "tokens",
-      "oracleId": "USDT",
+      "oracleId": "USDTo",
       "decimals": "1e6"
     }
   },

--- a/src/data/avax/pangolinv2LpPools.json
+++ b/src/data/avax/pangolinv2LpPools.json
@@ -475,25 +475,6 @@
     }
   },
   {
-    "name": "png-wavax-usdt.e",
-    "address": "0xe28984e1EE8D431346D32BeC9Ec800Efb643eef4",
-    "decimals": "1e18",
-    "poolId": 7,
-    "chainId": 43114,
-    "lp0": {
-      "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-      "oracle": "tokens",
-      "oracleId": "AVAX",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xc7198437980c041c805A1EDcbA50c1Ce5db95118",
-      "oracle": "tokens",
-      "oracleId": "USDT.e",
-      "decimals": "1e6"
-    }
-  },
-  {
     "name": "png-wavax-dai.e",
     "address": "0xbA09679Ab223C6bdaf44D45Ba2d7279959289AB0",
     "decimals": "1e18",
@@ -567,25 +548,6 @@
       "oracle": "tokens",
       "oracleId": "SPELL",
       "decimals": "1e18"
-    }
-  },
-  {
-    "name": "png-usdc.e-usdt.e",
-    "address": "0xc13E562d92F7527c4389Cd29C67DaBb0667863eA",
-    "decimals": "1e18",
-    "poolId": 2,
-    "chainId": 43114,
-    "lp0": {
-      "address": "0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664",
-      "oracle": "tokens",
-      "oracleId": "USDC.e",
-      "decimals": "1e6"
-    },
-    "lp1": {
-      "address": "0xc7198437980c041c805A1EDcbA50c1Ce5db95118",
-      "oracle": "tokens",
-      "oracleId": "USDT.e",
-      "decimals": "1e6"
     }
   },
   {


### PR DESCRIPTION
In conjunction with beefyfinance/beefy-app#1177, these changes will clean up the various USDT tokens used on the AVAX network.
* `USDTe` remains unchanged
* Address book contained a 'USDT-Tether USD' duplicate entry that is removed
* `USDt`, the Native Tether USD on Avax, changed to `USDT`
* Legacy instances of `USDT` are changed to `USDTo` which was already in use on some legacy (EOL) vaults.  This is not active anywhere on the platform.
* Token descriptions and names have been updated to include whether they are bridged and from where
* Several pools that are no longer present (EOL or otherwise) have been removed