### PR TITLE
Update Gelato Price Fetching

### DIFF
--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -458,6 +458,7 @@ const coinGeckoCoins = [
   'jpyc',
   'cad-coin',
   'xsgd',
+  'gelato',
 ];
 
 const knownPrices = {

--- a/src/data/fantom/beethovenxPools.json
+++ b/src/data/fantom/beethovenxPools.json
@@ -14,7 +14,7 @@
       },
       {
         "oracle": "tokens",
-        "oracleId": "GEL",
+        "oracleId": "gelato",
         "decimals": "1e18"
       }
     ]


### PR DESCRIPTION
No uniswap pools exist for GEL token (except on Ethereum), so fetching price from coingecko.
* https://github.com/beefyfinance/beefy-app/pull/1189