### PR TITLE
Adapt SpookyV2LpApys + add new pools

### DIFF
--- a/packages/address-book/address-book/fantom/tokens/tokens.ts
+++ b/packages/address-book/address-book/fantom/tokens/tokens.ts
@@ -38,6 +38,26 @@ const FTM = {
 } as const;
 
 const _tokens = {
+  sFTMx: {
+    name: 'sFTMx sFTMx',
+    symbol: 'sFTMx',
+    address: '0xd7028092c830b5C8FcE061Af2E593413EbbC1fc1',
+    chainId: 250,
+    decimals: 18,
+    logoURI: 'https://assets.spookyswap.finance/tokens/sFTMX.png',
+    website: 'https://fantom.staderlabs.com/liquid-staking/pools',
+    description: 'sFTMX is a liquid token that users get when they stake FTM with Stader.',
+  },
+  SD: {
+    name: 'Stader SD',
+    symbol: 'SD',
+    address: '0x412a13C109aC30f0dB80AD3Bd1DeFd5D0A6c0Ac6',
+    chainId: 250,
+    decimals: 18,
+    logoURI: 'https://s2.coinmarketcap.com/static/img/coins/64x64/12623.png',
+    website: 'https://staderlabs.com/',
+    description: 'Stader (SD) token is the native governance and value accrual token for Stader.',
+  },
   USDB: {
     name: 'USD Balance',
     symbol: 'UDSB',

--- a/packages/address-book/address-book/fantom/tokens/tokens.ts
+++ b/packages/address-book/address-book/fantom/tokens/tokens.ts
@@ -39,7 +39,7 @@ const FTM = {
 
 const _tokens = {
   sFTMx: {
-    name: 'sFTMx sFTMx',
+    name: 'sFTMx',
     symbol: 'sFTMx',
     address: '0xd7028092c830b5C8FcE061Af2E593413EbbC1fc1',
     chainId: 250,

--- a/src/abis/fantom/SpookyComplexRewarder.json
+++ b/src/abis/fantom/SpookyComplexRewarder.json
@@ -220,6 +220,56 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "childrenRewarders",
+    "outputs": [
+      {
+        "internalType": "contract IRewarder",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20Ext",
+        "name": "_rewardToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_rewardPerSecond",
+        "type": "uint256"
+      }
+    ],
+    "name": "createChild",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChildrenRewarders",
+    "outputs": [
+      {
+        "internalType": "contract IRewarder[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "massUpdatePools",
     "outputs": [],
@@ -394,6 +444,19 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "popChildren",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "_tokenAddress",
         "type": "address"
@@ -481,6 +544,19 @@
     "name": "setRewardPerSecond",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAllocPoint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/src/data/fantom/spookyV2LpPools.json
+++ b/src/data/fantom/spookyV2LpPools.json
@@ -1,5 +1,46 @@
 [
   {
+    "name": "boo-usdc-sd",
+    "address": "0xeaa3C87135eE1140E1D60FC8B577fbb41163D840",
+    "decimals": "1e18",
+    "poolId": 3,
+    "chainId": 250,
+    "lp0": {
+      "address": "0x04068DA6C83AFCFA0e13ba15A6696662335D5B75",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0x412a13C109aC30f0dB80AD3Bd1DeFd5D0A6c0Ac6",
+      "oracle": "tokens",
+      "oracleId": "SD",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "boo-wftm-sftmx",
+    "address": "0xE67980fc955FECfDA8A92BbbFBCc9f0C4bE60A9A",
+    "decimals": "1e18",
+    "poolId": 4,
+    "chainId": 250,
+    "oracleB": "tokens",
+    "oracleIdB": "SD",
+    "decimalsB": "1e18",
+    "lp0": {
+      "address": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
+      "oracle": "tokens",
+      "oracleId": "WFTM",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xd7028092c830b5C8FcE061Af2E593413EbbC1fc1",
+      "oracle": "tokens",
+      "oracleId": "sFTMx",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "boo-wftm-deus",
     "address": "0xaF918eF5b9f33231764A5557881E6D3e5277d456",
     "decimals": "1e18",
@@ -8,6 +49,7 @@
     "oracleB": "tokens",
     "oracleIdB": "DEUS",
     "decimalsB": "1e18",
+    "rewarderTotalAllocPoints": "200",
     "lp0": {
       "address": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
       "oracle": "tokens",
@@ -30,6 +72,7 @@
     "oracleB": "tokens",
     "oracleIdB": "DEUS",
     "decimalsB": "1e18",
+    "rewarderTotalAllocPoints": "200",
     "lp0": {
       "address": "0x04068DA6C83AFCFA0e13ba15A6696662335D5B75",
       "oracle": "tokens",

--- a/src/utils/fetchXPrices.js
+++ b/src/utils/fetchXPrices.js
@@ -9,7 +9,7 @@ import { getContract } from './contractHelper';
 
 const {
   fantom: {
-    tokens: { BOO, xBOO, SCREAM, xSCREAM, CREDIT, xCREDIT },
+    tokens: { BOO, xBOO, SCREAM, xSCREAM, CREDIT, xCREDIT, FTM, sFTMx },
   },
   polygon: {
     tokens: { QUICK, dQUICK },
@@ -24,6 +24,7 @@ const tokens = {
     [BOO, xBOO],
     [SCREAM, xSCREAM],
     [CREDIT, xCREDIT],
+    [FTM, sFTMx],
   ],
   polygon: [[QUICK, dQUICK]],
   fuse: [[VOLT, xVOLT]],


### PR DESCRIPTION
For the first two SpookySwapV2 farms, these two shared a ComplexRewarder for the second reward. This contract used allocPoints to split the rewards between the two farms, however it was lacking a totalAllocPoints interface. 
That is why a temporary solution had been implemented to iterate over all rewarders and sum up their allocPoints:
```
 // totalAllocPoint is not a public variable on the complex rewarder
 // find shared rewarders and sum their allocPoints
  ```

For the third V2 farm that is sFTMx-FTM, SpookySwap fixed their issue and deployed a new ComplexRewarder that contains the totalAllocPoints interface. 
In order to find a clean solution that works with the new ComplexRewarder and also supports the first two farms without the need for a distinct script, I optimized the script towards the new ComplexRewarder containing the totalAllocPoints interface and provided the first two pools with a static property for the totalAllocPonts of their rewarder, which is then picked up within the script.

Additionally, I made some adjustments to make SpookyV2LpApys work with traditional single reward farms as those will also be added to the masterchefV2 for future farms (see USDC-SD).