### PR TITLE
Fix Trisolaris USDC-NEAR Dual Reward pool

### DIFF
--- a/src/data/aurora/trisolarisMiniLpPools.json
+++ b/src/data/aurora/trisolarisMiniLpPools.json
@@ -33,7 +33,7 @@
     "lp0": {
       "address": "0xB12BFcA5A55806AaF64E99521918A4bf0fC40802",
       "oracle": "tokens",
-      "oracleId": "LINEAR",
+      "oracleId": "USDC",
       "decimals": "1e6"
     },
     "lp1": {


### PR DESCRIPTION
The recently added USDC-NEAR dual reward pool was reporting a wrong price and APY due to fat-fingered LP token symbol.

This should fix it.