### PR TITLE
Fix BSC BSHARE images

### DIFF
--- a/packages/address-book/address-book/bsc/tokens/tokens.ts
+++ b/packages/address-book/address-book/bsc/tokens/tokens.ts
@@ -70,7 +70,7 @@ const _tokens = {
     description:
       'BOMB is pegged via algorithm to a 10,000:1 ratio to BTC. $100k BTC = $10 BOMB PEG',
   },
-  BSHARE: {
+  BOMBSHARE: {
     name: 'BSHARE',
     symbol: 'BSHARE',
     address: '0x531780FAcE85306877D7e1F05d713D1B50a37F7A',


### PR DESCRIPTION
* Update address-book to use ID of BOMBSHARE for BSHARE on BSC, in order to differentiate from BSHARE (Based) on Fantom
* https://github.com/beefyfinance/beefy-app/issues/1219