### PR TITLE
FITFI-WAVAX LP

### DIFF
--- a/packages/address-book/address-book/avax/tokens/tokens.ts
+++ b/packages/address-book/address-book/avax/tokens/tokens.ts
@@ -4535,6 +4535,19 @@ const _tokens = {
       'Heroes of NFT is an online card game where you can attend tournaments and defeat your opponents to rise to victory.',
     logoURI: 'https://assets.coingecko.com/coins/images/23527/small/tokenlogo200.png?1644368289',
   },
+  FITFI: {
+    chainId: 43114,
+    address: '0x714f020C54cc9D104B6F4f6998C63ce2a31D1888',
+    decimals: 18,
+    name: 'STEP.APP',
+    symbol: 'FITFI',
+    website: 'https://step.app/',
+    description:
+      'Step App is creating a gamified metaverse for the fitness economy. Walk, jog, and run to socialize, play, and earn. - Stake to earn portion of ecosystem fees. - Stake includes a cooldown, breaking which causes a penalty. - Tiered stakers acquire discounts on NFT market.',
+
+    logoURI:
+      'https://assets.coingecko.com/coins/images/25015/small/801485424e1f49bc8d0facff9287eb9b_photo.png?1649827972',
+  },
 } as const;
 
 export const tokens: ConstRecord<typeof _tokens, Token> = _tokens;

--- a/src/data/avax/pangolinv2LpPools.json
+++ b/src/data/avax/pangolinv2LpPools.json
@@ -19,6 +19,25 @@
     }
   },
   {
+    "name": "png-fitfi-wavax",
+    "address": "0x1bB665942381FB2E67c4dCCb04E6CfE7f130E93C",
+    "decimals": "1e18",
+    "poolId": 109,
+    "chainId": 43114,
+    "lp0": {
+      "address": "0x714f020C54cc9D104B6F4f6998C63ce2a31D1888",
+      "oracle": "tokens",
+      "oracleId": "FITFI",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      "oracle": "tokens",
+      "oracleId": "WAVAX",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "png-wavax-usdc",
     "address": "0x0e0100Ab771E9288e0Aa97e11557E6654C3a9665",
     "decimals": "1e18",


### PR DESCRIPTION


Hym#6244 on discord. Vault has been tested (manually and with the provided tests) locally and everything works as intended.

I've used default contracts in the beefy-contracts repo, with no modifications.

PangolinFITFI-WAVAX

vault: 0x2b1b82D0D3F79D0Ff0300263F215Ed2dCE0734D2
strategy: 0xB8ff233d024277b0E188A478C18e9263330A1B51
Want: 0x1bB665942381FB2E67c4dCCb04E6CfE7f130E93C
PoolId: 109

farm: https://app.pangolin.exchange/#/png/0x714f020C54cc9D104B6F4f6998C63ce2a31D1888/AVAX/2


https://github.com/beefyfinance/beefy-app/pull/1228