### PR TITLE
Fix Hector TOR-2CRV LP price

### DIFF
--- a/src/api/stats/fantom/getHectorApy.ts
+++ b/src/api/stats/fantom/getHectorApy.ts
@@ -7,7 +7,7 @@ const singlePool = [
     name: 'hector-tor-crv',
     address: '0x24699312CB27C26Cfc669459D670559E5E44EE60',
     rewardPool: '0x61B71689684800f73eBb67378fc2e1527fbDC3b3',
-    oracleId: 'curve-ftm-tor',
+    oracleId: 'hector-tor-crv',
     chainId,
   },
 ];

--- a/src/data/fantom/curvePools.json
+++ b/src/data/fantom/curvePools.json
@@ -113,7 +113,7 @@
     "rewards": []
   },
   {
-    "name": "curve-ftm-tor",
+    "name": "hector-tor-crv",
     "pool": "0x24699312CB27C26Cfc669459D670559E5E44EE60",
     "rewards": []
   },


### PR DESCRIPTION
I noticed the [`hector-tor-crv` vault](https://app.beefy.finance/#/vault/hector-tor-crv) was displaying the wrong vault value ($1 per LP instead of the virtual price from the Curve pool). 

This fixes it. 