### PR TITLE
add lp breakdown data for beets as base for ui integration/testing

### DIFF
--- a/src/api/price/index.js
+++ b/src/api/price/index.js
@@ -1,4 +1,4 @@
-const { getAmmTokensPrices, getAmmLpPrices } = require('../stats/getAmmPrices');
+const { getAmmTokensPrices, getAmmLpPrices, getLpBreakdown } = require('../stats/getAmmPrices');
 const { getMooTokenPrices } = require('../stats/getMooTokenPrices');
 
 async function lpsPrices(ctx) {
@@ -32,8 +32,20 @@ async function mooTokenPrices(ctx) {
   }
 }
 
+async function lpsBreakdown(ctx) {
+  try {
+    const lpTokenBreakdown = await getLpBreakdown();
+    ctx.status = 200;
+    ctx.body = { ...lpTokenBreakdown };
+  } catch (err) {
+    console.error(err);
+    ctx.status = 500;
+  }
+}
+
 module.exports = {
   lpsPrices,
   tokenPrices,
   mooTokenPrices,
+  lpsBreakdown,
 };

--- a/src/api/stats/getNonAmmPrices.ts
+++ b/src/api/stats/getNonAmmPrices.ts
@@ -21,6 +21,7 @@ import getStellaswapPrices from './moonbeam/getStellaswapPrices';
 
 const getNonAmmPrices = async tokenPrices => {
   let prices = {};
+  let breakdown = {};
 
   const promises = [
     getBeethovenxPrices(tokenPrices),
@@ -53,10 +54,20 @@ const getNonAmmPrices = async tokenPrices => {
   results
     .filter((r): r is PromiseFulfilledResult<any> => r.status === 'fulfilled')
     .forEach(r => {
-      Object.assign(prices, r.value);
+      // If value for apy is an object, it contains breakdown
+      if (typeof r.value[Object.keys(r.value)[0]] === 'object') {
+        //Means breakdown data is available
+        Object.keys(r.value).forEach(lp => {
+          let lpData = r.value[lp];
+          prices[lp] = lpData.price;
+          breakdown[lp] = lpData;
+        });
+      } else {
+        Object.assign(prices, r.value);
+      }
     });
 
-  return prices;
+  return { prices, breakdown };
 };
 
 export default getNonAmmPrices;

--- a/src/router.js
+++ b/src/router.js
@@ -28,6 +28,7 @@ router.get('/earnings', gov.earnings);
 router.get('/holders', gov.holderCount);
 
 router.get('/lps', price.lpsPrices);
+router.get('/lps/breakdown', price.lpsBreakdown);
 router.get('/prices', price.tokenPrices);
 router.get('/mootokenprices', price.mooTokenPrices);
 


### PR DESCRIPTION
Give detail on lp composition on beethoven pools. This is a v1 for this feature, all lp with price calculations will be supported so that our app can show a detailed breakdown of how each user's money is distributed inside an lp. Added beethoven pools first since they offer a range of lengths for UI testing