### PR TITLE
Handling for expired dual rewards in VVS

### DIFF
--- a/src/data/cronos/vvsLpPools.json
+++ b/src/data/cronos/vvsLpPools.json
@@ -1,27 +1,5 @@
 [
   {
-    "name": "vvs-tusd-usdc",
-    "address": "0x94FD83482016BCC5FcA5972A3635aA6524C3F557",
-    "decimals": "1e18",
-    "oracleB": "tokens",
-    "oracleIdB": "TUSD",
-    "decimalsB": "1e18",
-    "poolId": 20,
-    "chainId": 25,
-    "lp0": {
-      "address": "0x87EFB3ec1576Dec8ED47e58B832bEdCd86eE186e",
-      "oracle": "tokens",
-      "oracleId": "TUSD",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xc21223249CA28397B4B6541dfFaEcC539BfF0c59",
-      "oracle": "tokens",
-      "oracleId": "USDC",
-      "decimals": "1e6"
-    }
-  },
-  {
     "name": "vvs-ape-cro",
     "address": "0x2eA92065D2c2908bB3C7d6BB9318aF4F8d735dD5",
     "decimals": "1e18",

--- a/src/data/cronos/vvsLpPools.json
+++ b/src/data/cronos/vvsLpPools.json
@@ -1,5 +1,27 @@
 [
   {
+    "name": "vvs-tusd-usdc",
+    "address": "0x94FD83482016BCC5FcA5972A3635aA6524C3F557",
+    "decimals": "1e18",
+    "oracleB": "tokens",
+    "oracleIdB": "TUSD",
+    "decimalsB": "1e18",
+    "poolId": 20,
+    "chainId": 25,
+    "lp0": {
+      "address": "0x87EFB3ec1576Dec8ED47e58B832bEdCd86eE186e",
+      "oracle": "tokens",
+      "oracleId": "TUSD",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xc21223249CA28397B4B6541dfFaEcC539BfF0c59",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    }
+  },
+  {
     "name": "vvs-ape-cro",
     "address": "0x2eA92065D2c2908bB3C7d6BB9318aF4F8d735dD5",
     "decimals": "1e18",


### PR DESCRIPTION
Calculations to not include expired dual reward in APY.


OLD INFO:

The pair seems to already exist on vvsDualLpPools.json. I didn't remove the entry there. Maybe the pool has rewarded dual rewards in the past, but currently it only rewards one token, VVS.

Vault: 0xA4D3044b9e790464A14c9801aBe39743d95498f2
Strategy: 0x9B43779d9223859821086430665c9C75Da039008
Want: 0x94FD83482016BCC5FcA5972A3635aA6524C3F557
PoolId: 20