### PR TITLE
Add Ripae(Cronos) + MATIC-PAE(QuickSwap)

### DIFF
--- a/packages/address-book/address-book/cronos/tokens/tokens.ts
+++ b/packages/address-book/address-book/cronos/tokens/tokens.ts
@@ -37,6 +37,28 @@ const _tokens = {
       'Ferro Protocol is a StableSwap AMM protocol that allows users to exchange with low slippage and minimum fee and farm tokens by creating more efficient pools consisting of highly correlated assets, as well as allowing better composability between protocols in the Cronos ecosystem.',
     logoURI: 'https://vvs.finance/images/tokens/0x39bC1e38c842C60775Ce37566D03B41A7A66C782.svg',
   },
+  sCRO: {
+    name: 'sCRO',
+    symbol: 'sCRO',
+    address: '0xA01fAe0612a4786ec296Be7f87b292F05c68186B',
+    chainId: 25,
+    decimals: 18,
+    website: 'https://cro.ripae.finance/',
+    description:
+      'Ripae Finance’s full focus is to build a true cross-chain algorithmic stable coin protocol that is stabilized with true use-cases all around the DeFi Ecosystem.',
+    logoURI: 'https://cro.ripae.finance/static/media/sCRO.f6637a43.svg',
+  },
+  pCRO: {
+    name: 'pCRO',
+    symbol: 'pCRO',
+    address: '0xA5e6a847f79BA19AAF41b8e1B2e6C4741234C6b7',
+    chainId: 25,
+    decimals: 18,
+    website: 'https://cro.ripae.finance/',
+    description:
+      'Ripae Finance’s full focus is to build a true cross-chain algorithmic stable coin protocol that is stabilized with true use-cases all around the DeFi Ecosystem.',
+    logoURI: 'https://cro.ripae.finance/static/media/pCRO.0d99b3b6.svg',
+  },
   APE: {
     name: 'APECoin',
     symbol: 'APE',

--- a/src/abis/cronos/RipaeRewardPool.json
+++ b/src/abis/cronos/RipaeRewardPool.json
@@ -1,0 +1,590 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pae",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_poolStartTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_treasuryFund",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "EmergencyWithdraw",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardPaid",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_allocPoint",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_withUpdate",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_lastRewardTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_depositFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "add",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
+    "name": "emergencyWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_fromTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_toTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "getGeneratedReward",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "governanceRecoverUnsupported",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "massUpdatePools",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "operator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pae",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "pendingPAE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "periodCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "periodEnds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "periodTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolEndTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "poolInfo",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "allocPoint",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastRewardTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "accPaePerShare",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isStarted",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "depositFee",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolStartTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "rewardPerSecond",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "runningTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_allocPoint",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_depositFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "set",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      }
+    ],
+    "name": "setOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_treasuryFund",
+        "type": "address"
+      }
+    ],
+    "name": "setTreasuryFund",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAllocPoint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasuryFund",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
+    "name": "updatePool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "userInfo",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rewardDebt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/api/stats/cronos/getRipaeApys.js
+++ b/src/api/stats/cronos/getRipaeApys.js
@@ -1,0 +1,116 @@
+const BigNumber = require('bignumber.js');
+const { MultiCall } = require('eth-multicall');
+const { cronosWeb3: web3, multicallAddress } = require('../../../utils/web3');
+
+const MasterChef = require('../../../abis/cronos/RipaeRewardPool.json');
+const ERC20 = require('../../../abis/ERC20.json');
+const fetchPrice = require('../../../utils/fetchPrice');
+const pools = require('../../../data/cronos/ripaeLpPools.json');
+const { BASE_HPY, CRONOS_CHAIN_ID } = require('../../../constants');
+const { getTradingFeeApr } = require('../../../utils/getTradingFeeApr');
+import { getFarmWithTradingFeesApy } from '../../../utils/getFarmWithTradingFeesApy';
+const { vvsClient } = require('../../../apollo/client');
+const { compound } = require('../../../utils/compound');
+import { getContract, getContractWithProvider } from '../../../utils/contractHelper';
+
+const masterchef = '0x83EA9d8748A7AD9f2F12B2A2F7a45CE47A862ac9';
+const oracleId = 'sCRO';
+const oracle = 'tokens';
+const DECIMALS = '1e18';
+
+const secondsPerYear = 31536000;
+
+const liquidityProviderFee = 0.003;
+const beefyPerformanceFee = 0.045;
+const shareAfterBeefyPerformanceFee = 1 - beefyPerformanceFee;
+
+const getRipaeApys = async () => {
+  let apys = {};
+  let apyBreakdowns = {};
+
+  const secondsPerBlock = 1;
+  const tokenPrice = await fetchPrice({ oracle: oracle, id: oracleId });
+  const { rewardPerSecond, totalAllocPoint } = await getMasterChefData();
+  const { balances, allocPoints } = await getPoolsData(pools);
+
+  const pairAddresses = pools.map(pool => pool.address);
+  const tradingAprs = await getTradingFeeApr(vvsClient, pairAddresses, liquidityProviderFee);
+
+  for (let i = 0; i < pools.length; i++) {
+    const pool = pools[i];
+
+    const lpPrice = await fetchPrice({ oracle: 'lps', id: pool.name });
+    const totalStakedInUsd = balances[i].times(lpPrice).dividedBy('1e18');
+
+    const poolBlockRewards = rewardPerSecond.times(allocPoints[i]).dividedBy(totalAllocPoint);
+    const yearlyRewards = poolBlockRewards.dividedBy(secondsPerBlock).times(secondsPerYear);
+    const yearlyRewardsInUsd = yearlyRewards.times(tokenPrice).dividedBy(DECIMALS);
+
+    const simpleApy = yearlyRewardsInUsd.dividedBy(totalStakedInUsd);
+    const vaultApr = simpleApy.times(shareAfterBeefyPerformanceFee);
+    const vaultApy = compound(simpleApy, BASE_HPY, 1, shareAfterBeefyPerformanceFee);
+
+    const tradingApr = tradingAprs[pool.address.toLowerCase()] ?? new BigNumber(0);
+    const totalApy = getFarmWithTradingFeesApy(
+      simpleApy,
+      tradingApr,
+      BASE_HPY,
+      1,
+      shareAfterBeefyPerformanceFee
+    );
+
+    const legacyApyValue = { [pool.name]: totalApy };
+
+    apys = { ...apys, ...legacyApyValue };
+
+    const componentValues = {
+      [pool.name]: {
+        vaultApr: vaultApr.toNumber(),
+        compoundingsPerYear: BASE_HPY,
+        beefyPerformanceFee: beefyPerformanceFee,
+        vaultApy: vaultApy,
+        lpFee: liquidityProviderFee,
+        tradingApr: tradingApr.toNumber(),
+        totalApy: totalApy,
+      },
+    };
+
+    apyBreakdowns = { ...apyBreakdowns, ...componentValues };
+  }
+
+  return {
+    apys,
+    apyBreakdowns,
+  };
+};
+
+const getMasterChefData = async () => {
+  const masterchefContract = getContractWithProvider(MasterChef, masterchef, web3);
+  const rewardPerSecond = new BigNumber(await masterchefContract.methods.rewardPerSecond(0).call());
+  const totalAllocPoint = new BigNumber(await masterchefContract.methods.totalAllocPoint().call());
+  return { rewardPerSecond, totalAllocPoint };
+};
+
+const getPoolsData = async pools => {
+  const masterchefContract = getContract(MasterChef, masterchef);
+  const multicall = new MultiCall(web3, multicallAddress(CRONOS_CHAIN_ID));
+  const balanceCalls = [];
+  const allocPointCalls = [];
+  pools.forEach(pool => {
+    const tokenContract = getContract(ERC20, pool.address);
+    balanceCalls.push({
+      balance: tokenContract.methods.balanceOf(pool.strat ?? masterchef),
+    });
+    allocPointCalls.push({
+      allocPoint: masterchefContract.methods.poolInfo(pool.poolId),
+    });
+  });
+
+  const res = await multicall.all([balanceCalls, allocPointCalls]);
+
+  const balances = res[0].map(v => new BigNumber(v.balance));
+  const allocPoints = res[1].map(v => v.allocPoint['1']);
+  return { balances, allocPoints };
+};
+
+module.exports = getRipaeApys;

--- a/src/api/stats/cronos/index.js
+++ b/src/api/stats/cronos/index.js
@@ -6,6 +6,7 @@ const getVvsApys = require('./getVvsApys');
 const getVvsDualApys = require('./getVvsDualApys');
 const getCronaApys = require('./getCronaApys');
 const getDarkApys = require('./getDarkApys');
+const getRipaeApys = require('./getRipaeApys');
 
 const getApys = [
   getVvsApys,
@@ -15,6 +16,7 @@ const getApys = [
   getCronosBifiMaxiApy,
   getLiquidusApys,
   getDarkApys,
+  getRipaeApys,
 ];
 
 const getCronosApys = async () => {

--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -235,6 +235,7 @@ import yuzuDualPools from '../../data/emerald/yuzuDualLpPools.json';
 import dfxPools from '../../data/matic/dfxLpPools.json';
 import ripaeMaticPools from '../../data/matic/ripaeLpPools.json';
 import velodromePools from '../../data/optimism/velodromeLpPools.json';
+import ripaeCronosPools from '../../data/cronos/ripaeLpPools.json';
 
 const INIT_DELAY = 2 * 1000;
 const REFRESH_INTERVAL = 5 * 60 * 1000;
@@ -242,6 +243,7 @@ const REFRESH_INTERVAL = 5 * 60 * 1000;
 // FIXME: if this list grows too big we might hit the ratelimit on initialization everytime
 // Implement in case of emergency -> https://github.com/beefyfinance/beefy-api/issues/103
 const pools = [
+  ...ripaeCronosPools,
   ...velodromePools,
   ...valleySwapLpPools,
   ...dfxPools,

--- a/src/data/cronos/ripaeLpPools.json
+++ b/src/data/cronos/ripaeLpPools.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "ripae-pcro-cro",
+    "address": "0xB0dC8B777DD82a951D688f8E5Dc4EBcB42D57C75",
+    "decimals": "1e18",
+    "poolId": 0,
+    "chainId": 25,
+    "lp0": {
+      "address": "0x5C7F8A570d578ED84E63fdFA7b1eE72dEae1AE23",
+      "oracle": "tokens",
+      "oracleId": "WCRO",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xA5e6a847f79BA19AAF41b8e1B2e6C4741234C6b7",
+      "oracle": "tokens",
+      "oracleId": "pCRO",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "ripae-scro-cro",
+    "address": "0xBa11E930e37721c91ea55fAA7BC2EcEfA05D1436",
+    "decimals": "1e18",
+    "poolId": 1,
+    "chainId": 25,
+    "lp0": {
+      "address": "0x5C7F8A570d578ED84E63fdFA7b1eE72dEae1AE23",
+      "oracle": "tokens",
+      "oracleId": "WCRO",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xA01fAe0612a4786ec296Be7f87b292F05c68186B",
+      "oracle": "tokens",
+      "oracleId": "sCRO",
+      "decimals": "1e18"
+    }
+  }
+]

--- a/src/data/matic/quickLpPools.json
+++ b/src/data/matic/quickLpPools.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "quick-matic-pae",
+    "address": "0x07D53b147eF96FAD1896D1156755A9Da7E06098E",
+    "rewardPool": "0xf8A04d1c6a3bF6ee3fB450d9bf394b2cEfbaAd9B",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+      "oracle": "tokens",
+      "oracleId": "WMATIC",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x8063037ea50E4a066bF1430EA1E3e609CD5cEf6B",
+      "oracle": "tokens",
+      "oracleId": "PAE",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "quick-matic-ldo",
     "address": "0xa0f330F5Fc47eE7A3297DBD6Be6Fe60cd0346B26",
     "rewardPool": "0xd04020De20df404D923c3b19e924878ead015b98",


### PR DESCRIPTION
## Due Diligence
sCRO is the new reward token and equals the native PAE on Fantom code wise. The only difference to PAE on Fantom are slightly different allocations and some corrected typos.
PAE(Fantom) vs sCRO diff: https://www.diffchecker.com/nWPUfmoT

ShareRewardPool introduces "periods" with different emission rates. Period intervals are set in the constructor and static (see diff)
PaeRewardPool(Avax) vs ShareRewardPool(Cronos) diff: https://www.diffchecker.com/15xoxbMG

pCRO is identical to the other Ripae peg tokens.
pAVAX vs pCRO diff: https://www.diffchecker.com/xIojGPZd

:heavy_check_mark: Token allocations are below 5% for EOAs and multi sigs
:warning:  pCRO ownership has been renounced but **sCRO ownership is not renounced yet!**

