### PR TITLE
FIX/ripae's arb

### DIFF
--- a/packages/address-book/address-book/arbitrum/tokens/tokens.ts
+++ b/packages/address-book/address-book/arbitrum/tokens/tokens.ts
@@ -222,7 +222,7 @@ const _tokens = {
       'Ripae Finance’s full focus is to build a true cross-chain algorithmic stable coin protocol that is stabilized with true use-cases all around the DeFi Ecosystem.',
     logoURI: '',
   },
-  pCRO: {
+  pETH: {
     name: 'pETH',
     symbol: 'pETH',
     address: '0xA0dF47432d9d88bcc040E9ee66dDC7E17A882715',

--- a/packages/address-book/address-book/arbitrum/tokens/tokens.ts
+++ b/packages/address-book/address-book/arbitrum/tokens/tokens.ts
@@ -211,7 +211,7 @@ const _tokens = {
     description:
       'Vesta Finance allows you to borrow collateralized stablecoin VST against supported crypto assets with no interest rate.',
   },
-  sETH: {
+  psETH: {
     name: 'sETH',
     symbol: 'sETH',
     address: '0x83EA9d8748A7AD9f2F12B2A2F7a45CE47A862ac9',

--- a/src/api/stats/arbitrum/getRipaeApys.js
+++ b/src/api/stats/arbitrum/getRipaeApys.js
@@ -13,7 +13,7 @@ const getRipaeApys = async () =>
     tokenPerBlock: 'paePerSecond',
     hasMultiplier: false,
     pools: pools,
-    oracleId: 'sETH',
+    oracleId: 'psETH',
     oracle: 'tokens',
     decimals: '1e18',
     secondsPerBlock: 1,

--- a/src/data/arbitrum/ripaeLpPools.json
+++ b/src/data/arbitrum/ripaeLpPools.json
@@ -33,7 +33,7 @@
     "lp1": {
       "address": "0x83EA9d8748A7AD9f2F12B2A2F7a45CE47A862ac9",
       "oracle": "tokens",
-      "oracleId": "sETH",
+      "oracleId": "psETH",
       "decimals": "1e18"
     }
   }


### PR DESCRIPTION
fix for https://github.com/beefyfinance/beefy-api/pull/861

- pCRO -> pETH
- sETH -> psETH because using sETH would create conflict with another sETH whom price is pulled from Coingecko, thus showing wrong apy for these 2 vaults.