### PR TITLE
Fix WONE price fetching

### DIFF
--- a/src/data/one/sushiLpPools.json
+++ b/src/data/one/sushiLpPools.json
@@ -369,7 +369,7 @@
     "lp0": {
       "address": "0x985458e523db3d53125813ed68c274899e9dfab4",
       "oracle": "tokens",
-      "oracleId": "USDC",
+      "oracleId": "1USDC",
       "decimals": "1e6"
     },
     "lp1": {


### PR DESCRIPTION
Pool had uncorrectly set USDC oracleId for a pool containing 1USDC which is no longer pegged.