### PR TITLE
Add test:ts script and fix errors with current config

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,13 +1,13 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+yarn test:ts
 yarn lint-staged
 
 SRC_PATTERN="packages/address-book"
 if git diff --cached --name-only | grep --quiet "$SRC_PATTERN"
 then
     cd packages/address-book
-    yarn test:ts
     yarn lint-staged
     yarn checksum
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,6 +7,7 @@ SRC_PATTERN="packages/address-book"
 if git diff --cached --name-only | grep --quiet "$SRC_PATTERN"
 then
     cd packages/address-book
+    yarn test:ts
     yarn lint-staged
     yarn checksum
 fi

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "heaptvl": "node -r ts-node/register --heap-prof src/api/stats/getTvl.js",
     "dev": "nodemon -e js,ts,json src/app.ts",
     "test": "nyc ava",
+    "test:ts": "tsc --noEmit",
     "prettier:check": "prettier --check src/**/*",
     "prettier:fix": "prettier --write src/**/*",
     "prepare": "husky install",

--- a/packages/address-book/types/chain.ts
+++ b/packages/address-book/types/chain.ts
@@ -2,7 +2,7 @@ import { BeefyFinance } from './beefyfinance';
 import type Token from './token';
 
 export default interface Chain {
-  readonly platforms: Record<string, Record<string, unknown>> & {
+  readonly platforms: Record<string, Record<string, string>> & {
     beefyfinance: BeefyFinance;
   };
   readonly tokens: Record<string, Token>;

--- a/scripts/add-farm.ts
+++ b/scripts/add-farm.ts
@@ -1,4 +1,15 @@
 import { ChainId, addressBook } from '../packages/address-book/address-book';
+import yargs from 'yargs';
+import fs from 'fs';
+import path from 'path';
+
+import { ethers } from 'ethers';
+import { MULTICHAIN_RPC } from '../src/constants';
+
+import masterchefABI from '../src/abis/MasterChef.json';
+import LPPairABI from '../src/abis/LPPair.json';
+import ERC20ABI from '../src/abis/ERC20.json';
+
 const {
   fantom: {
     platforms: { spookyswap },
@@ -25,17 +36,6 @@ const {
     platforms: { yuzu },
   },
 } = addressBook;
-
-const yargs = require('yargs');
-const fs = require('fs');
-const path = require('path');
-
-const { ethers } = require('ethers');
-const { MULTICHAIN_RPC } = require('../src/constants');
-
-const masterchefABI = require('../src/abis/MasterChef.json');
-const LPPairABI = require('../src/abis/LPPair.json');
-const ERC20ABI = require('../src/abis/ERC20.json');
 
 const projects = {
   pancake: {

--- a/scripts/add-omni.ts
+++ b/scripts/add-omni.ts
@@ -1,15 +1,15 @@
 import { ChainId } from '../packages/address-book/address-book';
 
-const yargs = require('yargs');
-const fs = require('fs');
-const path = require('path');
+import yargs from 'yargs';
+import fs from 'fs';
+import path from 'path';
 
-const { ethers } = require('ethers');
-const { MULTICHAIN_RPC } = require('../src/constants');
+import { ethers } from 'ethers';
+import { MULTICHAIN_RPC } from '../src/constants';
 
-const FarmABI = require('../src/abis/IOmnifarmFarm.json');
-const LPPairABI = require('../src/abis/LPPair.json');
-const ERC20ABI = require('../src/abis/ERC20.json');
+import FarmABI from '../src/abis/IOmnifarmFarm.json';
+import LPPairABI from '../src/abis/LPPair.json';
+import ERC20ABI from '../src/abis/ERC20.json';
 
 const projects = {
   omni: {

--- a/scripts/add-quick.ts
+++ b/scripts/add-quick.ts
@@ -1,15 +1,15 @@
 import { ChainId } from '../packages/address-book/address-book';
 
-const yargs = require('yargs');
-const fs = require('fs');
-const path = require('path');
+import yargs from 'yargs';
+import fs from 'fs';
+import path from 'path';
 
-const { ethers } = require('ethers');
-const { MULTICHAIN_RPC } = require('../src/constants');
+import { ethers } from 'ethers';
+import { MULTICHAIN_RPC } from '../src/constants';
 
-const rewardPoolABI = require('../src/abis/IStakingRewards.json');
-const LPPairABI = require('../src/abis/LPPair.json');
-const ERC20ABI = require('../src/abis/ERC20.json');
+import rewardPoolABI from '../src/abis/IStakingRewards.json';
+import LPPairABI from '../src/abis/LPPair.json';
+import ERC20ABI from '../src/abis/ERC20.json';
 
 const projects = {
   quick: {

--- a/scripts/add-solidly.ts
+++ b/scripts/add-solidly.ts
@@ -1,15 +1,15 @@
 import { ChainId } from '../packages/address-book/address-book';
 
-const yargs = require('yargs');
-const fs = require('fs');
-const path = require('path');
+import yargs from 'yargs';
+import fs from 'fs';
+import path from 'path';
 
-const { ethers } = require('ethers');
-const { MULTICHAIN_RPC } = require('../src/constants');
+import { ethers } from 'ethers';
+import { MULTICHAIN_RPC } from '../src/constants';
 
-const voterABI = require('../src/abis/Voter.json');
-const LPPairABI = require('../src/abis/ISolidlyPair.json');
-const ERC20ABI = require('../src/abis/ERC20.json');
+import voterABI from '../src/abis/Voter.json';
+import LPPairABI from '../src/abis/ISolidlyPair.json';
+import ERC20ABI from '../src/abis/ERC20.json';
 import { addressBook } from '../packages/address-book/address-book';
 const {
   fantom: {

--- a/scripts/add-sushi.ts
+++ b/scripts/add-sushi.ts
@@ -1,6 +1,17 @@
 import { ChainId } from '../packages/address-book/address-book';
 import { sushi } from '../packages/address-book/address-book/one/platforms/sushi';
 import { addressBook } from '../packages/address-book/address-book';
+import yargs from 'yargs';
+import fs from 'fs';
+import path from 'path';
+
+import { ethers } from 'ethers';
+import { MULTICHAIN_RPC } from '../src/constants';
+
+import masterchefABI from '../src/abis/matic/SushiMiniChefV2.json';
+import LPPairABI from '../src/abis/LPPair.json';
+import ERC20ABI from '../src/abis/ERC20.json';
+
 const {
   polygon: {
     platforms: { sushi: sushiPolygon },
@@ -21,17 +32,6 @@ const {
     platforms: { pegasys: pegasys },
   },
 } = addressBook;
-
-const yargs = require('yargs');
-const fs = require('fs');
-const path = require('path');
-
-const { ethers } = require('ethers');
-const { MULTICHAIN_RPC } = require('../src/constants');
-
-const masterchefABI = require('../src/abis/matic/SushiMiniChefV2.json');
-const LPPairABI = require('../src/abis/LPPair.json');
-const ERC20ABI = require('../src/abis/ERC20.json');
 
 const projects = {
   sushiOne: {

--- a/scripts/add-token.ts
+++ b/scripts/add-token.ts
@@ -1,11 +1,11 @@
 import { ChainId } from '../packages/address-book/address-book';
 
-const yargs = require('yargs');
+import yargs from 'yargs';
 
-const { ethers } = require('ethers');
-const { MULTICHAIN_RPC } = require('../src/constants');
+import { ethers } from 'ethers';
+import { MULTICHAIN_RPC } from '../src/constants';
 
-const ERC20ABI = require('../src/abis/ERC20.json');
+import ERC20ABI from '../src/abis/ERC20.json';
 
 const args = yargs.options({
   network: {

--- a/src/api/stats/arbitrum/getBalancerArbPrices.ts
+++ b/src/api/stats/arbitrum/getBalancerArbPrices.ts
@@ -1,7 +1,7 @@
-const getBalancerPrices = require('../common/getBalancerPrices');
-const { arbitrumWeb3: web3 } = require('../../../utils/web3');
-const { ARBITRUM_CHAIN_ID: chainId } = require('../../../constants');
-const balancerPools = require('../../../data/arbitrum/balancerArbLpPools.json');
+import getBalancerPrices from '../common/getBalancerPrices';
+import { arbitrumWeb3 as web3 } from '../../../utils/web3';
+import { ARBITRUM_CHAIN_ID as chainId } from '../../../constants';
+import balancerPools from '../../../data/arbitrum/balancerArbLpPools.json';
 
 const pools = [...balancerPools];
 
@@ -9,4 +9,4 @@ const getBalancerArbPrices = async tokenPrices => {
   return await getBalancerPrices(web3, chainId, pools, tokenPrices);
 };
 
-module.exports = getBalancerArbPrices;
+export default getBalancerArbPrices;

--- a/src/api/stats/common/getMultiRewardMasterChefApys.ts
+++ b/src/api/stats/common/getMultiRewardMasterChefApys.ts
@@ -66,12 +66,11 @@ const getTradingAprs = async (params: MasterChefApysParams) => {
   const fee = params.liquidityProviderFee;
   if (client && fee) {
     const pairAddresses = params.pools.map(pool => pool.address.toLowerCase());
-    const getAprs = isSushiClient(client)
-      ? getTradingFeeAprSushi
+    const aprs = isSushiClient(client)
+      ? getTradingFeeAprSushi(client, pairAddresses, fee)
       : isBeetClient(client)
-      ? getTradingFeeAprBalancer
-      : getTradingFeeApr;
-    const aprs = await getAprs(client, pairAddresses, fee);
+      ? getTradingFeeAprBalancer(client, pairAddresses, fee, params.chainId)
+      : getTradingFeeApr(client, pairAddresses, fee);
     tradingAprs = { ...tradingAprs, ...aprs };
   }
   return tradingAprs;

--- a/src/api/stats/fantom/getBeethovenxPrices.ts
+++ b/src/api/stats/fantom/getBeethovenxPrices.ts
@@ -1,9 +1,9 @@
-const getBalancerPrices = require('../common/getBalancerPrices');
-const { fantomWeb3: web3 } = require('../../../utils/web3');
-const { FANTOM_CHAIN_ID } = require('../../../constants');
-const beetsPools = require('../../../data/fantom/beethovenxPools.json');
-const beetsDualPools = require('../../../data/fantom/beethovenxDualPools.json');
-const fBeetsPool = require('../../../data/fantom/fBeetsPool.json');
+import getBalancerPrices from '../common/getBalancerPrices';
+import { fantomWeb3 as web3 } from '../../../utils/web3';
+import { FANTOM_CHAIN_ID } from '../../../constants';
+import beetsPools from '../../../data/fantom/beethovenxPools.json';
+import beetsDualPools from '../../../data/fantom/beethovenxDualPools.json';
+import fBeetsPool from '../../../data/fantom/fBeetsPool.json';
 
 const pools = [...beetsPools, ...fBeetsPool, ...beetsDualPools];
 
@@ -11,4 +11,4 @@ const getBeethovenxPrices = async tokenPrices => {
   return await getBalancerPrices(web3, FANTOM_CHAIN_ID, pools, tokenPrices);
 };
 
-module.exports = getBeethovenxPrices;
+export default getBeethovenxPrices;

--- a/src/api/stats/matic/getBalancerPolyPrices.ts
+++ b/src/api/stats/matic/getBalancerPolyPrices.ts
@@ -1,7 +1,7 @@
-const getBalancerPrices = require('../common/getBalancerPrices');
-const { polygonWeb3: web3 } = require('../../../utils/web3');
-const { POLYGON_CHAIN_ID: chainId } = require('../../../constants');
-const balancerPools = require('../../../data/matic/balancerPolyLpPools.json');
+import getBalancerPrices from '../common/getBalancerPrices';
+import { polygonWeb3 as web3 } from '../../../utils/web3';
+import { POLYGON_CHAIN_ID as chainId } from '../../../constants';
+import balancerPools from '../../../data/matic/balancerPolyLpPools.json';
 
 const pools = [...balancerPools];
 
@@ -9,4 +9,4 @@ const getBalancerPolyPrices = async tokenPrices => {
   return await getBalancerPrices(web3, chainId, pools, tokenPrices);
 };
 
-module.exports = getBalancerPolyPrices;
+export default getBalancerPolyPrices;

--- a/src/api/stats/matic/getJarvisPrices.ts
+++ b/src/api/stats/matic/getJarvisPrices.ts
@@ -1,7 +1,7 @@
-const getCurvePricesCommon = require('../common/curve/getCurvePricesCommon');
-const { polygonWeb3: web3 } = require('../../../utils/web3');
-const pools = require('../../../data/matic/jarvisPools.json');
-const rewardPool = require('../../../data/matic/jarvisRewardPool.json');
+import getCurvePricesCommon from '../common/curve/getCurvePricesCommon';
+import { polygonWeb3 as web3 } from '../../../utils/web3';
+import pools from '../../../data/matic/jarvisPools.json';
+import rewardPool from '../../../data/matic/jarvisRewardPool.json';
 import { fetchDmmPrices } from '../../../utils/fetchDmmPrices';
 
 const getJarvisPrices = async tokenPrices => {
@@ -10,4 +10,4 @@ const getJarvisPrices = async tokenPrices => {
   return dmmPrices.tokenPrices;
 };
 
-module.exports = getJarvisPrices;
+export default getJarvisPrices;

--- a/src/api/stats/matic/getMaticMasterChefApys.ts
+++ b/src/api/stats/matic/getMaticMasterChefApys.ts
@@ -8,7 +8,7 @@ import { POLYGON_CHAIN_ID, QUICK_LPF } from '../../../constants';
 import fetchPrice from '../../../utils/fetchPrice';
 import getBlockNumber from '../../../utils/getBlockNumber';
 import { getTradingFeeAprSushi, getTradingFeeApr } from '../../../utils/getTradingFeeApr';
-import { sushiClient } from '../../../apollo/client';
+import { sushiPolyClient as sushiClient } from '../../../apollo/client';
 import { AbiItem } from 'web3-utils';
 import { LpPool, SingleAssetPool } from '../../../types/LpPool';
 import { NormalizedCacheObject } from '@apollo/client/core';

--- a/src/api/stats/moonbeam/getStellaswapPrices.ts
+++ b/src/api/stats/moonbeam/getStellaswapPrices.ts
@@ -1,14 +1,14 @@
-const BigNumber = require('bignumber.js');
+import BigNumber from 'bignumber.js';
 import { MultiCall } from 'eth-multicall';
-const ISolarStablePool = require('../../../abis/moonriver/ISolarStablePool.json');
-const { moonriverWeb3: web3, multicallAddress } = require('../../../utils/web3');
-import { MOONRIVER_CHAIN_ID as chainId } from '../../../constants';
+import ISolarStablePool from '../../../abis/moonriver/ISolarStablePool.json';
+import { moonbeamWeb3 as web3, multicallAddress } from '../../../utils/web3';
+import { MOONBEAM_CHAIN_ID as chainId } from '../../../constants';
 import { getContract } from '../../../utils/contractHelper';
-const pools = require('../../../data/moonriver/solarbeamStablePools.json');
+import pools from '../../../data/moonbeam/stellaswapStablePools.json';
 
 const DECIMALS = '1e18';
 
-const getSolarbeamPrices = async tokenPrices => {
+const getStellaswapPrices = async tokenPrices => {
   let prices = {};
 
   const virtualPrices = await getVirtualPrice(tokenPrices);
@@ -51,4 +51,4 @@ const getTokenPrice = (tokenPrices, oracleId) => {
   return tokenPrice;
 };
 
-module.exports = getSolarbeamPrices;
+export default getStellaswapPrices;

--- a/src/api/stats/moonriver/getSolarbeamPrices.ts
+++ b/src/api/stats/moonriver/getSolarbeamPrices.ts
@@ -1,14 +1,14 @@
-const BigNumber = require('bignumber.js');
+import BigNumber from 'bignumber.js';
 import { MultiCall } from 'eth-multicall';
-const ISolarStablePool = require('../../../abis/moonriver/ISolarStablePool.json');
-const { moonbeamWeb3: web3, multicallAddress } = require('../../../utils/web3');
-import { MOONBEAM_CHAIN_ID as chainId } from '../../../constants';
+import ISolarStablePool from '../../../abis/moonriver/ISolarStablePool.json';
+import { moonriverWeb3 as web3, multicallAddress } from '../../../utils/web3';
+import { MOONRIVER_CHAIN_ID as chainId } from '../../../constants';
 import { getContract } from '../../../utils/contractHelper';
-const pools = require('../../../data/moonbeam/stellaswapStablePools.json');
+import pools from '../../../data/moonriver/solarbeamStablePools.json';
 
 const DECIMALS = '1e18';
 
-const getStellaswapPrices = async tokenPrices => {
+const getSolarbeamPrices = async tokenPrices => {
   let prices = {};
 
   const virtualPrices = await getVirtualPrice(tokenPrices);
@@ -51,4 +51,4 @@ const getTokenPrice = (tokenPrices, oracleId) => {
   return tokenPrice;
 };
 
-module.exports = getStellaswapPrices;
+export default getSolarbeamPrices;

--- a/src/api/stats/optimism/getBeetsOPPrices.ts
+++ b/src/api/stats/optimism/getBeetsOPPrices.ts
@@ -1,7 +1,7 @@
-const getBalancerPrices = require('../common/getBalancerPrices');
-const { optimismWeb3: web3 } = require('../../../utils/web3');
-const { OPTIMISM_CHAIN_ID: chainId } = require('../../../constants');
-const beetsPools = require('../../../data/optimism/beethovenxLpPools.json');
+import getBalancerPrices from '../common/getBalancerPrices';
+import { optimismWeb3 as web3 } from '../../../utils/web3';
+import { OPTIMISM_CHAIN_ID as chainId } from '../../../constants';
+import beetsPools from '../../../data/optimism/beethovenxLpPools.json';
 
 const pools = [...beetsPools];
 
@@ -9,4 +9,4 @@ const getBeetsOPPrices = async tokenPrices => {
   return await getBalancerPrices(web3, chainId, pools, tokenPrices);
 };
 
-module.exports = getBeetsOPPrices;
+export default getBeetsOPPrices;

--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -1,14 +1,20 @@
-const fetch = require('node-fetch');
-const createHttpLink = require('apollo-link-http').createHttpLink;
-import { ApolloClient, InMemoryCache } from '@apollo/client/core';
+import fetch from 'node-fetch';
+import { createHttpLink } from 'apollo-link-http';
+import {
+  ApolloClient,
+  ApolloLink,
+  InMemoryCache,
+  NormalizedCacheObject,
+  RequestHandler,
+} from '@apollo/client/core';
 import ApolloLinkTimeout from 'apollo-link-timeout';
 
-const APOLLO_TIMEOUT = process.env.APOLLO_TIMEOUT || 30_000;
-const timeoutLink = new ApolloLinkTimeout(APOLLO_TIMEOUT);
+const APOLLO_TIMEOUT = process.env.APOLLO_TIMEOUT ? parseInt(process.env.APOLLO_TIMEOUT) : 30_000;
+const timeoutLink: ApolloLink = new ApolloLinkTimeout(APOLLO_TIMEOUT);
 
-function client(url) {
+function client(url: string) {
   const httpLink = createHttpLink({ uri: url, fetch });
-  const timeoutHttpLink = timeoutLink.concat(httpLink);
+  const timeoutHttpLink = timeoutLink.concat(httpLink as any as ApolloLink | RequestHandler);
   return new ApolloClient({
     link: timeoutHttpLink,
     cache: new InMemoryCache({
@@ -98,7 +104,7 @@ const tombswapClient = client('https://api.thegraph.com/subgraphs/name/github-qf
 const biswapClient = client('https://api.thegraph.com/subgraphs/name/biswapcom/exchange5');
 const pegasysClient = client('https://graph.pegasys.exchange/subgraphs/name/pollum-io/pegasys');
 
-const isSushiClient = client => {
+const isSushiClient = (client: ApolloClient<NormalizedCacheObject>) => {
   return (
     client === sushiPolyClient ||
     client === sushiOneClient ||
@@ -112,11 +118,11 @@ const isSushiClient = client => {
   );
 };
 
-const isBeetClient = client => {
+const isBeetClient = (client: ApolloClient<NormalizedCacheObject>) => {
   return client === beetClient || client === beetOpClient;
 };
 
-module.exports = {
+export {
   dinoClient,
   joeClient,
   dfynClient,

--- a/src/utils/fetchDmmPrices.ts
+++ b/src/utils/fetchDmmPrices.ts
@@ -1,11 +1,12 @@
-const BigNumber = require('bignumber.js');
-const { ethers } = require('ethers');
-const { MULTICHAIN_RPC } = require('../constants');
+import BigNumber from 'bignumber.js';
+import { ethers } from 'ethers';
+import { MULTICHAIN_RPC } from '../constants';
 import { multicallAddress, web3Factory } from './web3';
 import { MultiCall } from 'eth-multicall';
 import { getContract } from './contractHelper';
-const DMMPool = require('../abis/DMMPool');
-const ERC20 = require('../abis/common/ERC20/ERC20.json');
+import DMMPool from '../abis/DMMPool.json';
+import ERC20 from '../abis/common/ERC20/ERC20.json';
+import { ChainId } from '../../packages/address-book/address-book';
 
 const sortByKeys = o => {
   return Object.keys(o)
@@ -44,7 +45,7 @@ const calcLpPrice = (pool, tokenPrices) => {
   };
 };
 
-const fetchDmmPrices = async (pools, knownPrices) => {
+export const fetchDmmPrices = async (pools, knownPrices) => {
   let prices = { ...knownPrices };
   let lps = {};
   let breakdown = {};
@@ -53,7 +54,7 @@ const fetchDmmPrices = async (pools, knownPrices) => {
     weights[known] = Number.MAX_SAFE_INTEGER;
   });
 
-  const chainIds = pools.map(p => p.chainId);
+  const chainIds: ChainId[] = pools.map(p => p.chainId);
   const uniqueChainIds = [...new Set(chainIds)];
 
   for (let i = 0; i < uniqueChainIds.length; i++) {
@@ -148,5 +149,3 @@ const fetchDmmPrices = async (pools, knownPrices) => {
     lpsBreakdown: sortByKeys(breakdown),
   };
 };
-
-module.exports = { fetchDmmPrices };

--- a/src/utils/fetchMooPrices.ts
+++ b/src/utils/fetchMooPrices.ts
@@ -1,12 +1,12 @@
-const BigNumber = require('bignumber.js');
-const { ethers } = require('ethers');
-const { MULTICHAIN_RPC } = require('../constants');
+import BigNumber from 'bignumber.js';
+import { ethers } from 'ethers';
+import { MULTICHAIN_RPC } from '../constants';
 import { multicallAddress, web3Factory } from './web3';
 import { MultiCall } from 'eth-multicall';
 import { getContract } from './contractHelper';
 import { ChainId } from '../../packages/address-book/address-book';
 
-const IVault = require('../abis/BeefyVaultV6');
+import IVault from '../abis/BeefyVaultV6.json';
 
 const fetchMooPrices = async (pools, tokenPrices, lpPrices) => {
   let moo = {};
@@ -21,7 +21,7 @@ const fetchMooPrices = async (pools, tokenPrices, lpPrices) => {
 };
 
 const fetchPpfs = async pools => {
-  const chainIds = pools.map(p => p.chainId);
+  const chainIds: ChainId[] = pools.map(p => p.chainId);
   const uniqueChainIds = [...new Set(chainIds)];
 
   for (let i = 0; i < uniqueChainIds.length; i++) {
@@ -56,7 +56,7 @@ const fetchPpfs = async pools => {
 
 //Fetches ppfs for **vaults** from a single chain
 const fetchChainVaultsPpfs = async (vaults, chain) => {
-  const chainId = ChainId[chain];
+  const chainId = ChainId[chain] as any as ChainId;
   const web3 = web3Factory(chainId);
   const multicall = new MultiCall(web3, multicallAddress(chainId));
   const ppfsCalls = [];
@@ -82,4 +82,4 @@ const calcMooPrice = (pool, tokenPrices, lpPrices) => {
   return { [pool.name]: mooPrice.toNumber() };
 };
 
-module.exports = { fetchMooPrices, fetchChainVaultsPpfs };
+export { fetchMooPrices, fetchChainVaultsPpfs };

--- a/src/utils/fetchStargatePrices.ts
+++ b/src/utils/fetchStargatePrices.ts
@@ -1,15 +1,15 @@
-const BigNumber = require('bignumber.js');
-const { MultiCall } = require('eth-multicall');
-const { web3Factory, multicallAddress } = require('./web3');
-const StargateLP = require('../abis/StargateLP.json');
+import BigNumber from 'bignumber.js';
+import { MultiCall } from 'eth-multicall';
+import { web3Factory, multicallAddress } from './web3';
+import StargateLP from '../abis/StargateLP.json';
 
 import {
-    FANTOM_CHAIN_ID,
-    BSC_CHAIN_ID,
-    AVAX_CHAIN_ID,
-    OPTIMISM_CHAIN_ID,
-    ARBITRUM_CHAIN_ID,
-    POLYGON_CHAIN_ID
+  FANTOM_CHAIN_ID,
+  BSC_CHAIN_ID,
+  AVAX_CHAIN_ID,
+  OPTIMISM_CHAIN_ID,
+  ARBITRUM_CHAIN_ID,
+  POLYGON_CHAIN_ID,
 } from '../constants';
 import { addressBook } from '../../packages/address-book/address-book';
 import { getContract } from './contractHelper';
@@ -32,7 +32,7 @@ const {
   },
   polygon: {
     tokens: { spUSDC, spUSDT },
-  }
+  },
 } = addressBook;
 
 const tokens = {
@@ -99,11 +99,11 @@ const fetchStargatePrices = async tokenPrices =>
     getStargatePrices(tokenPrices, tokens.avax, AVAX_CHAIN_ID),
     getStargatePrices(tokenPrices, tokens.optimism, OPTIMISM_CHAIN_ID),
     getStargatePrices(tokenPrices, tokens.arbitrum, ARBITRUM_CHAIN_ID),
-    getStargatePrices(tokenPrices, tokens.polygon, POLYGON_CHAIN_ID)
+    getStargatePrices(tokenPrices, tokens.polygon, POLYGON_CHAIN_ID),
   ]).then(data =>
     data
       .flat()
       .reduce((acc, cur, i) => ((acc[Object.values(tokens).flat()[i][1].symbol] = cur), acc), {})
   );
 
-module.exports = { fetchStargatePrices };
+export { fetchStargatePrices };

--- a/src/utils/fetchXPrices.ts
+++ b/src/utils/fetchXPrices.ts
@@ -1,7 +1,7 @@
-const BigNumber = require('bignumber.js');
-const { MultiCall } = require('eth-multicall');
-const { web3Factory, multicallAddress } = require('./web3');
-const ERC20 = require('../abis/ERC20.json');
+import BigNumber from 'bignumber.js';
+import { MultiCall } from 'eth-multicall';
+import { web3Factory, multicallAddress } from './web3';
+import ERC20 from '../abis/ERC20.json';
 
 import {
   FANTOM_CHAIN_ID,
@@ -90,4 +90,4 @@ const fetchXPrices = async tokenPrices =>
       .reduce((acc, cur, i) => ((acc[Object.values(tokens).flat()[i][1].symbol] = cur), acc), {})
   );
 
-module.exports = { fetchXPrices };
+export { fetchXPrices };

--- a/src/utils/fetchbeFTMPrice.ts
+++ b/src/utils/fetchbeFTMPrice.ts
@@ -1,6 +1,6 @@
-const BigNumber = require('bignumber.js');
-const { web3Factory } = require('./web3');
-const SOLID = require('../abis/SolidPair.json');
+import BigNumber from 'bignumber.js';
+import { web3Factory } from './web3';
+import SOLID from '../abis/SolidPair.json';
 
 import { FANTOM_CHAIN_ID } from '../constants';
 import { getContractWithProvider } from './contractHelper';
@@ -24,4 +24,4 @@ const getbeFTMPrice = async (tokenPrices, chainId) => {
   return price.toNumber();
 };
 
-module.exports = { fetchbeFTMPrice };
+export { fetchbeFTMPrice };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,9 @@
     "checkJs": false,
     "resolveJsonModule": true,
 
+    "disableSizeLimit": true,
+    //"noImplicitAny": true,
+
     "strict": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,9 +26,6 @@
     "checkJs": false,
     "resolveJsonModule": true,
 
-    "disableSizeLimit": true,
-    //"noImplicitAny": true,
-
     "strict": false
   }
 }


### PR DESCRIPTION
This PR adds a yarn script named `test:ts` that triggers the TS compiler in `noEmit` mode.
This script should fail if any typescript error is found.

Changes include:
- renaming some `.js` files to `.ts`
- using `import` instead of `require`
- using `export` instead of `module.exports`
- small local type fixes

Note the this may break external scripts directly importing from source and not from the build folder, but this should be marginal hopefully.

Next step will be to add `"noImplicitAny": true,` to the `tsconfig.json` file so we get stronger guarantees when updating the api code.