### PR TITLE
Vault fee data endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "date-fns": "^2.21.3",
     "eth-multicall": "^1.4",
     "ethereum-abi-types-generator": "^1.1.7",
+    "ethereum-multicall": "^2.14.1",
     "ethers": "^5.0.26",
     "graphql": "^15.5.0",
     "graphql-tag": "^2.12.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "apollo-link-timeout": "^4.0.0",
     "bignumber.js": "^9.0.1",
     "date-fns": "^2.21.3",
-    "eth-multicall": "^1.3.13",
+    "eth-multicall": "^1.4",
     "ethereum-abi-types-generator": "^1.1.7",
     "ethers": "^5.0.26",
     "graphql": "^15.5.0",

--- a/src/abis/FeeABI.json
+++ b/src/abis/FeeABI.json
@@ -1,0 +1,294 @@
+[
+  {
+    "inputs": [],
+    "name": "strategistFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "STRATEGIST_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "callFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "callfee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CALL_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "beefyFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "TREASURY_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "REWARDS_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardsFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CALL_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WITHDRAWAL_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "max",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFees",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "total",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "beefy",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "call",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "strategist",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "label",
+            "type": "string"
+          },
+          {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct IFeeConfig.FeeCategory",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawalFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WITHDRAWAL_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WITHDRAWAL_MAX",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawalMax",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abis/FeeABI.json
+++ b/src/abis/FeeABI.json
@@ -144,32 +144,6 @@
   },
   {
     "inputs": [],
-    "name": "CALL_FEE",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "WITHDRAWAL_FEE",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "MAX_FEE",
     "outputs": [
       {

--- a/src/abis/FeeABI.json
+++ b/src/abis/FeeABI.json
@@ -40,6 +40,19 @@
   },
   {
     "inputs": [],
+    "name": "callFeeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "callfee",
     "outputs": [
       {
@@ -158,6 +171,32 @@
   {
     "inputs": [],
     "name": "MAX_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_CALL_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxfee",
     "outputs": [
       {
         "internalType": "uint256",

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -191,11 +191,6 @@ const getChainFees = async (vaults, chainId, feeBatch: FeeBatchDetail) => {
     });
 
     for (let i = 0; i < contractCallContext.length; i += MULTICALL_BATCH_SIZE) {
-      console.log(
-        `${chainId} : ${((100 * (i + MULTICALL_BATCH_SIZE)) / contractCallContext.length).toFixed(
-          2
-        )}%`
-      );
       let batch = contractCallContext.slice(i, i + MULTICALL_BATCH_SIZE);
       const results: ContractCallResults = await multicall.call(batch);
 

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -1,5 +1,6 @@
 const { MultiCall } = require('eth-multicall');
 import { performance } from 'perf_hooks';
+import Web3 from 'web3';
 import { addressBookByChainId, ChainId } from '../../../packages/address-book/address-book';
 import { getContract, getContractWithProvider } from '../../utils/contractHelper';
 import { getKey, setKey } from '../../utils/redisHelper';
@@ -9,133 +10,162 @@ const FeeABI = require('../../abis/FeeABI.json');
 const { getMultichainVaults } = require('../stats/getMultichainVaults');
 const BigNumber = require('bignumber.js');
 
+const feeBatchTreasurySplitMethodABI = [
+  {
+    inputs: [],
+    name: 'treasuryFee',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+const INIT_DELAY = 20000;
+const REFRESH_INTERVAL = 20 * 60 * 1000;
 const VAULT_FEES_KEY = 'VAULT_FEES';
 const FEE_BATCH_KEY = 'FEE_BATCHES';
 
-interface BeefyFee {
+interface PerformanceFee {
   total: number;
+  call: number;
+  strategist: number;
   treasury: number;
   stakers: number;
 }
 
 interface VaultFeeBreakdown {
-  performance: {
-    total: number;
-    call: number;
-    strategist: number;
-    beefy: {
-      total: number;
-      treasury: number;
-      stakers: number;
-    };
-  };
+  performance: PerformanceFee;
   withdraw: number;
   lastUpdated: number;
 }
 
-var feeBatches: Record<ChainId, string>;
+interface FeeBatchDetail {
+  address: string;
+  treasurySplit: number;
+  stakerSplit: number;
+}
+
+var feeBatches: Record<ChainId, FeeBatchDetail>;
 var vaultFees: Record<string, VaultFeeBreakdown>;
 
 const updateFeeBatches = async () => {
-  Object.keys(addressBookByChainId).forEach(chainId => {
-    feeBatches[chainId] = addressBookByChainId[chainId].platforms.beefyfinance.beefyFeeRecipient;
-  });
+  for (const chainId of Object.keys(addressBookByChainId)) {
+    const feeBatchAddress = addressBookByChainId[chainId].platforms.beefyfinance.beefyFeeRecipient;
+    const web3 = web3Factory(Number(chainId));
+
+    const feeBatchContract = getContractWithProvider(
+      feeBatchTreasurySplitMethodABI,
+      feeBatchAddress,
+      web3
+    );
+
+    let treasurySplit;
+
+    try {
+      treasurySplit = await feeBatchContract.methods.treasuryFee().call();
+    } catch (err) {
+      //If reverted, method isn't available on contract so must be older split
+      if (err.message.includes('revert') || err.message.includes('correct ABI')) {
+        treasurySplit = 140;
+      } else {
+        console.log(' > Error updating feeBatch on chain ' + chainId);
+        console.log(err.message);
+      }
+    }
+
+    if (treasurySplit) {
+      feeBatches[chainId] = {
+        address: feeBatchAddress,
+        treasurySplit: treasurySplit / 1000,
+        stakerSplit: 1 - treasurySplit / 1000,
+      };
+    } else {
+      console.log('Failed to update feeBatch on chain ' + chainId);
+    }
+  }
+
   setKey(FEE_BATCH_KEY, feeBatches);
   console.log(`> feeBatches updated`);
 };
 
 const updateVaultFees = async () => {
+  console.log(`> updating vault fees`);
+  let start = Date.now();
   let vaults = getMultichainVaults();
 
-  const chainVaults = vaults.filter(
-    vault => !vault.id.includes('-maxi') && vault.chain === 'arbitrum'
-  );
-  // await getChainFees(chainVaults, ChainId.arbitrum)
-  // console.log(chainVaults[0])
-  // await getBreakdown(chainVaults[0], ChainId.optimism)
+  let promises = [];
 
-  for (const chain of Object.values(ChainId).filter(c => isNaN(Number(c)))) {
-    console.log('~~~~~~~');
-    console.log(chain);
-    const chainVaults = vaults.filter(
-      vault => !vault.id.includes('-maxi') && vault.chain === chain
-    );
-
-    try {
-      await getChainFees(chainVaults, ChainId[chain]);
-    } catch (err) {
-      console.log(` > Failed to update fees on chain ` + chain);
-      console.log(err.message);
-    }
-    console.log('finished chain');
+  for (const chain of Object.keys(addressBookByChainId).map(c => Number(c))) {
+    const chainVaults = vaults
+      .filter(vault => vault.chain === ChainId[chain])
+      .filter(
+        v => !vaultFees[v.id] || Date.now() - vaultFees[v.id].lastUpdated > 1000 * 60 * 60 * 12
+      );
+    promises.push(getChainFees(chainVaults, chain, feeBatches[chain]));
   }
+
+  await Promise.allSettled(promises);
+  await saveToRedis();
+
+  console.log(`> updated vault fees (${(Date.now() - start) / 1000}s)`);
+
+  setTimeout(updateVaultFees, REFRESH_INTERVAL);
 };
 
-const getBreakdown = async (vault, chainId) => {
-  const web3 = web3Factory(chainId);
-  const contract = getContractWithProvider(FeeABI, vault.strategy, web3);
-  const contractNoProv = getContract(FeeABI, vault.strategy);
-  let res = await contract.methods.getFees().call();
-  console.log(res);
-  console.log(multicallAddress(chainId));
-  const multicall = new MultiCall(web3, multicallAddress(chainId));
-  const feeCalls = [];
-  feeCalls.push({
-    fees: contractNoProv.methods.getFees(),
-  });
-  let res2 = await multicall.all([feeCalls]);
-  console.log(res2);
-  console.log(res2[0][0].fees);
+const saveToRedis = async () => {
+  await setKey(VAULT_FEES_KEY, vaultFees);
 };
 
-const getChainFees = async (vaults, chainId) => {
-  const web3 = web3Factory(chainId);
-  const multicall = new MultiCall(web3, multicallAddress(chainId));
-  const feeCalls = [];
+const getChainFees = async (vaults, chainId, feeBatch: FeeBatchDetail) => {
+  try {
+    const web3 = web3Factory(chainId);
+    const multicall = new MultiCall(web3, multicallAddress(chainId));
+    const feeCalls = [];
 
-  console.log(vaults[0].chain);
-  vaults.forEach(vault => {
-    const strategyContract = getContract(FeeABI, vault.strategy);
+    vaults.forEach(vault => {
+      const strategyContract = getContract(FeeABI, vault.strategy);
 
-    // All past iterations of fee data naming in strategies
-    feeCalls.push({
-      id: vault.id,
-      strategy: vault.strategy,
-      strategist: strategyContract.methods.strategistFee(),
-      strategist2: strategyContract.methods.STRATEGIST_FEE(),
-      call: strategyContract.methods.callFee(),
-      CALL: strategyContract.methods.CALL_FEE(),
-      call3: strategyContract.methods.callfee(),
-      beefy: strategyContract.methods.beefyFee(),
-      fee: strategyContract.methods.fee(),
-      treasury: strategyContract.methods.TREASURY_FEE(),
-      rewards: strategyContract.methods.REWARDS_FEE(),
-      rewards2: strategyContract.methods.rewardsFee(),
-      breakdown: strategyContract.methods.getFees(),
-      maxFee: strategyContract.methods.MAX_FEE(),
-      maxFee2: strategyContract.methods.max(),
-      withdraw: strategyContract.methods.withdrawalFee(),
-      withdraw2: strategyContract.methods.WITHDRAWAL_FEE(),
-      withdrawMax: strategyContract.methods.WITHDRAWAL_MAX(),
-      withdrawMax2: strategyContract.methods.withdrawalMax(),
-      paused: strategyContract.methods.paused(),
+      // All past iterations of fee data naming in strategies
+      feeCalls.push({
+        id: vault.id,
+        strategy: vault.strategy,
+        strategist: strategyContract.methods.strategistFee(),
+        strategist2: strategyContract.methods.STRATEGIST_FEE(),
+        call: strategyContract.methods.callFee(),
+        CALL: strategyContract.methods.CALL_FEE(),
+        call3: strategyContract.methods.callfee(),
+        call4: strategyContract.methods.callFeeAmount(),
+        maxCallFee: strategyContract.methods.MAX_CALL_FEE(),
+        beefy: strategyContract.methods.beefyFee(),
+        fee: strategyContract.methods.fee(),
+        treasury: strategyContract.methods.TREASURY_FEE(),
+        rewards: strategyContract.methods.REWARDS_FEE(),
+        rewards2: strategyContract.methods.rewardsFee(),
+        breakdown: strategyContract.methods.getFees(),
+        maxFee: strategyContract.methods.MAX_FEE(),
+        maxFee2: strategyContract.methods.max(),
+        maxFee3: strategyContract.methods.maxfee(),
+        withdraw: strategyContract.methods.withdrawalFee(),
+        withdraw2: strategyContract.methods.WITHDRAWAL_FEE(),
+        withdrawMax: strategyContract.methods.WITHDRAWAL_MAX(),
+        withdrawMax2: strategyContract.methods.withdrawalMax(),
+        paused: strategyContract.methods.paused(),
+      });
     });
-  });
 
-  const res = await multicall.all([feeCalls]);
-  const feeResults = res[0];
-  for (const contractCalls of res[0]) {
-    let fees = await mapStrategyCallsToFeeBreakdown(contractCalls, web3);
-    if (fees) {
-    } else {
+    const res = await multicall.all([feeCalls]);
+    const feeResults = res[0];
+    for (const contractCalls of res[0]) {
+      let fees = await mapStrategyCallsToFeeBreakdown(contractCalls, web3, feeBatch);
+      if (fees) {
+        vaultFees[contractCalls.id] = fees;
+      } else {
+        console.log(' > Failed to get fees for ' + contractCalls.id);
+      }
     }
+  } catch (err) {
+    console.log(err.message);
   }
-
-  // let filtered = feeResults.filter(r => r.breakdown !== undefined);
-  // console.log(filtered)
-  // if (feeResults.filter(r => r.withdrawMax === undefined).length > 0) {
-  //     console.log(feeResults.filter(r => r.withdrawMax === undefined))
-  // }
 };
 
 const withdrawalFeeFromCalls = methodCalls => {
@@ -151,79 +181,223 @@ const withdrawalFeeFromCalls = methodCalls => {
   }
 };
 
-const legacyFeeMappings = async methodCalls => {
+const legacyFeeMappings = (methodCalls, feeBatch: FeeBatchDetail): PerformanceFee => {
   let total = 4.5;
+  let performanceFee: PerformanceFee;
 
-  let callFee = parseFloat(methodCalls.call ?? methodCalls.CALL ?? methodCalls.call3);
+  let callFee = parseFloat(
+    methodCalls.call ?? methodCalls.CALL ?? methodCalls.call3 ?? methodCalls.call4
+  );
+  let maxCallFee = parseFloat(methodCalls.maxCallFee ?? 1000);
   let strategistFee = parseFloat(methodCalls.strategist ?? methodCalls.strategist2);
-  let maxFee = parseFloat(methodCalls.maxFee ?? methodCalls.maxFee2);
+  let maxFee = parseFloat(methodCalls.maxFee ?? methodCalls.maxFee2 ?? methodCalls.maxFee3);
   let beefyFee = parseFloat(methodCalls.beefy);
   let fee = parseFloat(methodCalls.fee);
   let treasury = parseFloat(methodCalls.treasury);
   let rewards = parseFloat(methodCalls.rewards ?? methodCalls.rewards2);
 
-  if (callFee + strategistFee + beefyFee !== maxFee) {
-    if (callFee + strategistFee + rewards + treasury !== maxFee) {
-      if (callFee + treasury + rewards !== maxFee) {
-        if (fee + callFee !== maxFee) {
-          if (strategistFee + callFee + treasury !== maxFee) {
-            if (
-              strategistFee !== undefined &&
-              callFee !== undefined &&
-              beefyFee !== undefined &&
-              maxFee !== undefined
-            ) {
-            }
-          }
-        }
-      }
-    }
-  }
-  return 1;
-};
-
-const performanceFeesFromCalls = async (methodCalls, web3) => {
-  if (methodCalls.breakdown !== undefined) {
-    //newest method
-    //Requires an RPC call so a sleep to rate-limit is used
-    await sleep(1000);
-    const strategyContract = getContractWithProvider(FeeABI, methodCalls.strategy, web3);
-    const fees = await strategyContract.methods.getFees().call();
-
-    let total = new BigNumber(fees.total).div(1e9).toNumber() / 1e9;
-    let beefy = new BigNumber(fees.beefy).div(1e9).toNumber() / 1e9;
-    let call = new BigNumber(fees.call).div(1e9).toNumber() / 1e9;
-    let strategist = new BigNumber(fees.strategist).div(1e9).toNumber() / 1e9;
-
-    const feeSum = beefy + call + strategist;
-    const beefySplit = ((total * beefy) / feeSum) * 100;
-
-    let feeBreakdown = {
-      total: (total * 100).toFixed(2),
-      call: (((total * call) / feeSum) * 100).toFixed(4),
-      strategist: (((total * strategist) / feeSum) * 100).toFixed(2),
-      beefy: {
-        total: beefySplit.toFixed(2),
-        treasury: (0.64 * beefySplit).toFixed(2),
-        stakers: (0.36 * beefySplit).toFixed(2),
-      },
+  if (callFee + strategistFee + beefyFee === maxFee) {
+    performanceFee = {
+      total,
+      call: (total * callFee) / maxFee,
+      strategist: (total * strategistFee) / maxFee,
+      treasury: (total * feeBatch.treasurySplit * beefyFee) / maxFee,
+      stakers: (total * feeBatch.stakerSplit * beefyFee) / maxFee,
     };
-    return feeBreakdown;
+  } else if (callFee + strategistFee + rewards + treasury === maxFee) {
+    performanceFee = {
+      total,
+      call: (total * callFee) / maxFee,
+      strategist: (total * strategistFee) / maxFee,
+      treasury: (total * treasury) / maxFee,
+      stakers: (total * rewards) / maxFee,
+    };
+  } else if (fee + callFee === maxFee) {
+    total = 5;
+    performanceFee = {
+      total: total,
+      call: (total * callFee) / maxFee,
+      strategist: 0,
+      treasury: 0,
+      stakers: (total * rewards) / maxFee,
+    };
+  } else if (!isNaN(strategistFee + callFee + beefyFee)) {
+    performanceFee = {
+      total,
+      call: (total * callFee) / maxFee,
+      strategist: (total * strategistFee) / maxFee,
+      treasury: (total * feeBatch.treasurySplit * beefyFee) / maxFee,
+      stakers: (total * feeBatch.stakerSplit * beefyFee) / maxFee,
+    };
+  } else if (!isNaN(strategistFee + callFee + treasury)) {
+    performanceFee = {
+      total,
+      call: (total * callFee) / maxFee,
+      strategist: (total * strategistFee) / maxFee,
+      treasury: (total * treasury) / maxFee,
+      stakers: 0,
+    };
+  } else if (callFee + treasury + rewards === maxFee) {
+    performanceFee = {
+      total,
+      call: (total * callFee) / maxFee,
+      strategist: 0,
+      treasury: (total * treasury) / maxFee,
+      stakers: (total * rewards) / maxFee,
+    };
+  } else if (callFee + beefyFee === maxFee) {
+    if (methodCalls.id === 'cake-cakev2-eol') total = 1;
+    performanceFee = {
+      total,
+      call: (total * callFee) / maxFee,
+      strategist: 0,
+      treasury: (total * feeBatch.treasurySplit * beefyFee) / maxFee,
+      stakers: (total * feeBatch.stakerSplit * beefyFee) / maxFee,
+    };
+  } else if (callFee + fee === maxFee) {
+    performanceFee = {
+      total,
+      call: (total * callFee) / maxFee,
+      strategist: 0,
+      treasury: 0,
+      stakers: (total * fee) / maxFee,
+    };
   } else {
-    return await legacyFeeMappings(methodCalls);
+    console.log(`> Performance fee fetch failed for: ${methodCalls.id} - ${methodCalls.strategy}`);
+  }
+
+  return performanceFee;
+};
+
+const performanceFromGetFees = async (
+  contractCalls,
+  web3: Web3,
+  feeBatch: FeeBatchDetail
+): Promise<PerformanceFee> => {
+  await sleep(1000);
+  const strategyContract = getContractWithProvider(FeeABI, contractCalls.strategy, web3);
+  const fees = await strategyContract.methods.getFees().call();
+
+  let total = new BigNumber(fees.total).div(1e9).toNumber() / 1e9;
+  let beefy = new BigNumber(fees.beefy).div(1e9).toNumber() / 1e9;
+  let call = new BigNumber(fees.call).div(1e9).toNumber() / 1e9;
+  let strategist = new BigNumber(fees.strategist).div(1e9).toNumber() / 1e9;
+
+  const feeSum = beefy + call + strategist;
+  const beefySplit = ((total * beefy) / feeSum) * 100;
+
+  let feeBreakdown = {
+    total: total * 100,
+    call: ((total * call) / feeSum) * 100,
+    strategist: ((total * strategist) / feeSum) * 100,
+    treasury: feeBatch.treasurySplit * beefySplit,
+    stakers: feeBatch.stakerSplit * beefySplit,
+  };
+  return feeBreakdown;
+};
+
+const performanceForMaxi = async (contractCalls): Promise<PerformanceFee> => {
+  let performanceFee: PerformanceFee;
+
+  let callFee = parseFloat(
+    contractCalls.call ?? contractCalls.CALL ?? contractCalls.call3 ?? contractCalls.call4
+  );
+  let maxCallFee = parseFloat(contractCalls.maxCallFee ?? 1000);
+  let maxFee = parseFloat(contractCalls.maxFee ?? contractCalls.maxFee2 ?? contractCalls.maxFee3);
+  let rewards = parseFloat(contractCalls.rewards ?? contractCalls.rewards2);
+
+  let strategyAddress = contractCalls.strategy.toLowerCase();
+
+  // Specific contracts with distinct method for charging fees
+  if (
+    [
+      '0x436D5127F16fAC1F021733dda090b5E6DE30b3bB'.toLowerCase(),
+      '0xa9E6E271b27b20F65394914f8784B3B860dBd259'.toLowerCase(),
+    ].includes(strategyAddress)
+  ) {
+    performanceFee = {
+      total: (callFee / 1000) * 100,
+      strategist: 0,
+      call: (callFee / 1000) * 100,
+      treasury: 0,
+      stakers: 0,
+    };
+
+    //Another bunch of legacy contracts
+  } else if (
+    [
+      '0x24AAaB9DA14308bAf9d670e2a37369FE8Cb5Fe36',
+      '0x22b3d90BDdC3Ad5F2948bE3914255C64Ebc8c9b3',
+      '0xbCF1e02ac0c45729dC85F290C4A6AB35c4801cB1',
+      '0xb25eB9105549627050AAB3A1c909fBD454014beA',
+    ]
+      .map(address => address.toLowerCase())
+      .includes(strategyAddress)
+  ) {
+    performanceFee = {
+      total: (4.5 * callFee) / maxFee,
+      strategist: 0,
+      call: (4.5 * callFee) / maxFee,
+      treasury: 0,
+      stakers: 0,
+    };
+  } else if ('0xca077eEC87e2621F5B09AFE47C42BAF88c6Af18c'.toLowerCase() === strategyAddress) {
+    performanceFee = {
+      total: (5 / 1000) * 100,
+      strategist: 0,
+      call: (5 / 1000) * 100,
+      treasury: 0,
+      stakers: 0,
+    };
+  } else if ('0x87056F5E8Dce0fD71605E6E291C6a3B53cbc3818'.toLowerCase() === strategyAddress) {
+    performanceFee = {
+      total: ((callFee + rewards) / maxFee) * 100,
+      strategist: 0,
+      call: (callFee / maxFee) * 100,
+      treasury: 0,
+      stakers: (rewards / maxFee) * 100,
+    };
+  } else {
+    performanceFee = {
+      total: (callFee / maxCallFee) * 100,
+      strategist: 0,
+      call: (callFee / maxCallFee) * 100,
+      treasury: 0,
+      stakers: 0,
+    };
+  }
+  return performanceFee;
+};
+
+const performanceFeesFromCalls = async (
+  methodCalls,
+  web3: Web3,
+  feeBatch: FeeBatchDetail
+): Promise<PerformanceFee> => {
+  if (methodCalls.id.includes('-maxi')) {
+    return performanceForMaxi(methodCalls);
+  } else if (methodCalls.breakdown !== undefined) {
+    //newest method
+    return await performanceFromGetFees(methodCalls, web3, feeBatch);
+  } else {
+    return legacyFeeMappings(methodCalls, feeBatch);
   }
 };
 
-const mapStrategyCallsToFeeBreakdown = async (methodCalls, web3) => {
+const mapStrategyCallsToFeeBreakdown = async (
+  methodCalls,
+  web3: Web3,
+  feeBatch: FeeBatchDetail
+) => {
   let withdrawFee = withdrawalFeeFromCalls(methodCalls);
 
-  let performanceFee = await performanceFeesFromCalls(methodCalls, web3);
+  let performanceFee = await performanceFeesFromCalls(methodCalls, web3, feeBatch);
 
   if (withdrawFee === undefined) {
     console.log(`Failed to find withdrawFee for ${methodCalls.id}`);
     return undefined;
   } else if (performanceFee === undefined) {
-    console.log(`Failed to find performance for ${methodCalls.id}`);
+    console.log(`Failed to find performanceFee for ${methodCalls.id}`);
     return undefined;
   }
 
@@ -245,5 +419,9 @@ export const initVaultFeeService = async () => {
 
   setTimeout(() => {
     updateVaultFees();
-  }, 15000);
+  }, INIT_DELAY);
+};
+
+export const getVaultFees = async () => {
+  return vaultFees;
 };

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -44,8 +44,8 @@ interface FeeBatchDetail {
   stakerSplit: number;
 }
 
-var feeBatches: Record<ChainId, FeeBatchDetail>;
-var vaultFees: Record<string, VaultFeeBreakdown>;
+let feeBatches: Record<ChainId, FeeBatchDetail>;
+let vaultFees: Record<string, VaultFeeBreakdown>;
 
 const updateFeeBatches = async () => {
   for (const chainId of Object.keys(addressBookByChainId)) {
@@ -83,7 +83,7 @@ const updateFeeBatches = async () => {
     }
   }
 
-  setKey(FEE_BATCH_KEY, feeBatches);
+  await setKey(FEE_BATCH_KEY, feeBatches);
   console.log(`> feeBatches updated`);
 };
 

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -211,7 +211,8 @@ const getChainFees = async (vaults, chainId, feeBatch: FeeBatchDetail) => {
 const withdrawalFeeFromCalls = methodCalls => {
   if (
     (methodCalls.withdraw === undefined && methodCalls.withdraw2 === undefined) ||
-    (methodCalls.withdrawMax === undefined && methodCalls.withdrawMax2 === undefined)
+    (methodCalls.withdrawMax === undefined && methodCalls.withdrawMax2 === undefined) ||
+    methodCalls.paused
   ) {
     return 0;
   } else {

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -1,0 +1,249 @@
+const { MultiCall } = require('eth-multicall');
+import { performance } from 'perf_hooks';
+import { addressBookByChainId, ChainId } from '../../../packages/address-book/address-book';
+import { getContract, getContractWithProvider } from '../../utils/contractHelper';
+import { getKey, setKey } from '../../utils/redisHelper';
+import { sleep } from '../../utils/time';
+import { multicallAddress, web3Factory } from '../../utils/web3';
+const FeeABI = require('../../abis/FeeABI.json');
+const { getMultichainVaults } = require('../stats/getMultichainVaults');
+const BigNumber = require('bignumber.js');
+
+const VAULT_FEES_KEY = 'VAULT_FEES';
+const FEE_BATCH_KEY = 'FEE_BATCHES';
+
+interface BeefyFee {
+  total: number;
+  treasury: number;
+  stakers: number;
+}
+
+interface VaultFeeBreakdown {
+  performance: {
+    total: number;
+    call: number;
+    strategist: number;
+    beefy: {
+      total: number;
+      treasury: number;
+      stakers: number;
+    };
+  };
+  withdraw: number;
+  lastUpdated: number;
+}
+
+var feeBatches: Record<ChainId, string>;
+var vaultFees: Record<string, VaultFeeBreakdown>;
+
+const updateFeeBatches = async () => {
+  Object.keys(addressBookByChainId).forEach(chainId => {
+    feeBatches[chainId] = addressBookByChainId[chainId].platforms.beefyfinance.beefyFeeRecipient;
+  });
+  setKey(FEE_BATCH_KEY, feeBatches);
+  console.log(`> feeBatches updated`);
+};
+
+const updateVaultFees = async () => {
+  let vaults = getMultichainVaults();
+
+  const chainVaults = vaults.filter(
+    vault => !vault.id.includes('-maxi') && vault.chain === 'arbitrum'
+  );
+  // await getChainFees(chainVaults, ChainId.arbitrum)
+  // console.log(chainVaults[0])
+  // await getBreakdown(chainVaults[0], ChainId.optimism)
+
+  for (const chain of Object.values(ChainId).filter(c => isNaN(Number(c)))) {
+    console.log('~~~~~~~');
+    console.log(chain);
+    const chainVaults = vaults.filter(
+      vault => !vault.id.includes('-maxi') && vault.chain === chain
+    );
+
+    try {
+      await getChainFees(chainVaults, ChainId[chain]);
+    } catch (err) {
+      console.log(` > Failed to update fees on chain ` + chain);
+      console.log(err.message);
+    }
+    console.log('finished chain');
+  }
+};
+
+const getBreakdown = async (vault, chainId) => {
+  const web3 = web3Factory(chainId);
+  const contract = getContractWithProvider(FeeABI, vault.strategy, web3);
+  const contractNoProv = getContract(FeeABI, vault.strategy);
+  let res = await contract.methods.getFees().call();
+  console.log(res);
+  console.log(multicallAddress(chainId));
+  const multicall = new MultiCall(web3, multicallAddress(chainId));
+  const feeCalls = [];
+  feeCalls.push({
+    fees: contractNoProv.methods.getFees(),
+  });
+  let res2 = await multicall.all([feeCalls]);
+  console.log(res2);
+  console.log(res2[0][0].fees);
+};
+
+const getChainFees = async (vaults, chainId) => {
+  const web3 = web3Factory(chainId);
+  const multicall = new MultiCall(web3, multicallAddress(chainId));
+  const feeCalls = [];
+
+  console.log(vaults[0].chain);
+  vaults.forEach(vault => {
+    const strategyContract = getContract(FeeABI, vault.strategy);
+
+    // All past iterations of fee data naming in strategies
+    feeCalls.push({
+      id: vault.id,
+      strategy: vault.strategy,
+      strategist: strategyContract.methods.strategistFee(),
+      strategist2: strategyContract.methods.STRATEGIST_FEE(),
+      call: strategyContract.methods.callFee(),
+      CALL: strategyContract.methods.CALL_FEE(),
+      call3: strategyContract.methods.callfee(),
+      beefy: strategyContract.methods.beefyFee(),
+      fee: strategyContract.methods.fee(),
+      treasury: strategyContract.methods.TREASURY_FEE(),
+      rewards: strategyContract.methods.REWARDS_FEE(),
+      rewards2: strategyContract.methods.rewardsFee(),
+      breakdown: strategyContract.methods.getFees(),
+      maxFee: strategyContract.methods.MAX_FEE(),
+      maxFee2: strategyContract.methods.max(),
+      withdraw: strategyContract.methods.withdrawalFee(),
+      withdraw2: strategyContract.methods.WITHDRAWAL_FEE(),
+      withdrawMax: strategyContract.methods.WITHDRAWAL_MAX(),
+      withdrawMax2: strategyContract.methods.withdrawalMax(),
+      paused: strategyContract.methods.paused(),
+    });
+  });
+
+  const res = await multicall.all([feeCalls]);
+  const feeResults = res[0];
+  for (const contractCalls of res[0]) {
+    let fees = await mapStrategyCallsToFeeBreakdown(contractCalls, web3);
+    if (fees) {
+    } else {
+    }
+  }
+
+  // let filtered = feeResults.filter(r => r.breakdown !== undefined);
+  // console.log(filtered)
+  // if (feeResults.filter(r => r.withdrawMax === undefined).length > 0) {
+  //     console.log(feeResults.filter(r => r.withdrawMax === undefined))
+  // }
+};
+
+const withdrawalFeeFromCalls = methodCalls => {
+  if (
+    (methodCalls.withdraw === undefined && methodCalls.withdraw2 === undefined) ||
+    (methodCalls.withdraMax === undefined && methodCalls.withdrawMax2 === undefined)
+  ) {
+    return 0;
+  } else {
+    let withdrawFee = parseFloat(methodCalls.withdraw ?? methodCalls.withdraw2);
+    let maxWithdrawFee = parseFloat(methodCalls.withdraMax ?? methodCalls.withdrawMax2);
+    return withdrawFee / maxWithdrawFee;
+  }
+};
+
+const legacyFeeMappings = async methodCalls => {
+  let total = 4.5;
+
+  let callFee = parseFloat(methodCalls.call ?? methodCalls.CALL ?? methodCalls.call3);
+  let strategistFee = parseFloat(methodCalls.strategist ?? methodCalls.strategist2);
+  let maxFee = parseFloat(methodCalls.maxFee ?? methodCalls.maxFee2);
+  let beefyFee = parseFloat(methodCalls.beefy);
+  let fee = parseFloat(methodCalls.fee);
+  let treasury = parseFloat(methodCalls.treasury);
+  let rewards = parseFloat(methodCalls.rewards ?? methodCalls.rewards2);
+
+  if (callFee + strategistFee + beefyFee !== maxFee) {
+    if (callFee + strategistFee + rewards + treasury !== maxFee) {
+      if (callFee + treasury + rewards !== maxFee) {
+        if (fee + callFee !== maxFee) {
+          if (strategistFee + callFee + treasury !== maxFee) {
+            if (
+              strategistFee !== undefined &&
+              callFee !== undefined &&
+              beefyFee !== undefined &&
+              maxFee !== undefined
+            ) {
+            }
+          }
+        }
+      }
+    }
+  }
+  return 1;
+};
+
+const performanceFeesFromCalls = async (methodCalls, web3) => {
+  if (methodCalls.breakdown !== undefined) {
+    //newest method
+    //Requires an RPC call so a sleep to rate-limit is used
+    await sleep(1000);
+    const strategyContract = getContractWithProvider(FeeABI, methodCalls.strategy, web3);
+    const fees = await strategyContract.methods.getFees().call();
+
+    let total = new BigNumber(fees.total).div(1e9).toNumber() / 1e9;
+    let beefy = new BigNumber(fees.beefy).div(1e9).toNumber() / 1e9;
+    let call = new BigNumber(fees.call).div(1e9).toNumber() / 1e9;
+    let strategist = new BigNumber(fees.strategist).div(1e9).toNumber() / 1e9;
+
+    const feeSum = beefy + call + strategist;
+    const beefySplit = ((total * beefy) / feeSum) * 100;
+
+    let feeBreakdown = {
+      total: (total * 100).toFixed(2),
+      call: (((total * call) / feeSum) * 100).toFixed(4),
+      strategist: (((total * strategist) / feeSum) * 100).toFixed(2),
+      beefy: {
+        total: beefySplit.toFixed(2),
+        treasury: (0.64 * beefySplit).toFixed(2),
+        stakers: (0.36 * beefySplit).toFixed(2),
+      },
+    };
+    return feeBreakdown;
+  } else {
+    return await legacyFeeMappings(methodCalls);
+  }
+};
+
+const mapStrategyCallsToFeeBreakdown = async (methodCalls, web3) => {
+  let withdrawFee = withdrawalFeeFromCalls(methodCalls);
+
+  let performanceFee = await performanceFeesFromCalls(methodCalls, web3);
+
+  if (withdrawFee === undefined) {
+    console.log(`Failed to find withdrawFee for ${methodCalls.id}`);
+    return undefined;
+  } else if (performanceFee === undefined) {
+    console.log(`Failed to find performance for ${methodCalls.id}`);
+    return undefined;
+  }
+
+  return {
+    performance: performanceFee,
+    withdraw: withdrawFee,
+    lastUpdated: Date.now(),
+  };
+};
+
+export const initVaultFeeService = async () => {
+  const cachedVaultFees = await getKey(VAULT_FEES_KEY);
+  const cachedFeeBatches = await getKey(FEE_BATCH_KEY);
+
+  feeBatches = cachedFeeBatches ?? {};
+  vaultFees = cachedVaultFees ?? {};
+
+  await updateFeeBatches();
+
+  setTimeout(() => {
+    updateVaultFees();
+  }, 15000);
+};

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -18,7 +18,8 @@ const feeBatchTreasurySplitMethodABI = [
 ];
 
 const INIT_DELAY = 16000;
-const REFRESH_INTERVAL = 20 * 60 * 1000;
+const REFRESH_INTERVAL = 10 * 60 * 1000;
+const CACHE_EXPIRY = 1000 * 60 * 60 * 12;
 const MULTICALL_BATCH_SIZE = 128;
 
 const VAULT_FEES_KEY = 'VAULT_FEES';
@@ -128,9 +129,7 @@ const updateVaultFees = async () => {
   for (const chain of Object.keys(addressBookByChainId).map(c => Number(c))) {
     const chainVaults = vaults
       .filter(vault => vault.chain === ChainId[chain])
-      .filter(
-        v => !vaultFees[v.id] || Date.now() - vaultFees[v.id].lastUpdated > 1000 * 60 * 60 * 12
-      );
+      .filter(v => !vaultFees[v.id] || Date.now() - vaultFees[v.id].lastUpdated > CACHE_EXPIRY);
     promises.push(getChainFees(chainVaults, chain, feeBatches[chain]));
   }
 

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -126,10 +126,11 @@ const updateVaultFees = async () => {
   let promises = [];
 
   for (const chain of Object.keys(addressBookByChainId).map(c => Number(c))) {
-    const chainVaults = vaults.filter(vault => vault.chain === ChainId[chain]);
-    // .filter(
-    //   v => !vaultFees[v.id] || Date.now() - vaultFees[v.id].lastUpdated > 1000 * 60 * 60 * 12
-    // );
+    const chainVaults = vaults
+      .filter(vault => vault.chain === ChainId[chain])
+      .filter(
+        v => !vaultFees[v.id] || Date.now() - vaultFees[v.id].lastUpdated > 1000 * 60 * 60 * 12
+      );
     promises.push(getChainFees(chainVaults, chain, feeBatches[chain]));
   }
 

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -211,12 +211,12 @@ const getChainFees = async (vaults, chainId, feeBatch: FeeBatchDetail) => {
 const withdrawalFeeFromCalls = methodCalls => {
   if (
     (methodCalls.withdraw === undefined && methodCalls.withdraw2 === undefined) ||
-    (methodCalls.withdraMax === undefined && methodCalls.withdrawMax2 === undefined)
+    (methodCalls.withdrawMax === undefined && methodCalls.withdrawMax2 === undefined)
   ) {
     return 0;
   } else {
     let withdrawFee = parseFloat(methodCalls.withdraw ?? methodCalls.withdraw2);
-    let maxWithdrawFee = parseFloat(methodCalls.withdraMax ?? methodCalls.withdrawMax2);
+    let maxWithdrawFee = parseFloat(methodCalls.withdrawMax ?? methodCalls.withdrawMax2);
     return withdrawFee / maxWithdrawFee;
   }
 };

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -366,9 +366,9 @@ const performanceForMaxi = (contractCalls): PerformanceFee => {
       .includes(strategyAddress)
   ) {
     performanceFee = {
-      total: 4.5 * callFee,
+      total: ((45 / 1000) * callFee) / maxFee,
       strategist: 0,
-      call: 4.5 * callFee,
+      call: ((45 / 1000) * callFee) / maxFee,
       treasury: 0,
       stakers: 0,
     };

--- a/src/api/vaults/getVaultFees.ts
+++ b/src/api/vaults/getVaultFees.ts
@@ -1,12 +1,8 @@
-// const { MultiCall } = require('eth-multicall');
 import { ContractCallContext, ContractCallResults, Multicall } from 'ethereum-multicall';
-import Web3 from 'web3';
 import { addressBookByChainId, ChainId } from '../../../packages/address-book/address-book';
-import { getContract, getContractWithProvider } from '../../utils/contractHelper';
+import { getContractWithProvider } from '../../utils/contractHelper';
 import { getKey, setKey } from '../../utils/redisHelper';
-import { sleep } from '../../utils/time';
-import { multicallAddress, web3Factory } from '../../utils/web3';
-// import { Multicall, ContractCallResults, ContractCallContext } from 'ethereum-multicall';
+import { web3Factory } from '../../utils/web3';
 const FeeABI = require('../../abis/FeeABI.json');
 const { getMultichainVaults } = require('../stats/getMultichainVaults');
 const BigNumber = require('bignumber.js');
@@ -99,10 +95,11 @@ const updateVaultFees = async () => {
   let promises = [];
 
   for (const chain of Object.keys(addressBookByChainId).map(c => Number(c))) {
-    const chainVaults = vaults.filter(vault => vault.chain === ChainId[chain]);
-    // .filter(
-    //   v => !vaultFees[v.id] || Date.now() - vaultFees[v.id].lastUpdated > 1000 * 60 * 60 * 12
-    // );
+    const chainVaults = vaults
+      .filter(vault => vault.chain === ChainId[chain])
+      .filter(
+        v => !vaultFees[v.id] || Date.now() - vaultFees[v.id].lastUpdated > 1000 * 60 * 60 * 12
+      );
     promises.push(getChainFees(chainVaults, chain, feeBatches[chain]));
   }
 
@@ -204,7 +201,6 @@ const getChainFees = async (vaults, chainId, feeBatch: FeeBatchDetail) => {
           console.log(' > Failed to get fees for ' + contractCalls.id);
         }
       }
-      // await sleep(200);
     }
   } catch (err) {
     console.log('error on chain ' + chainId);

--- a/src/api/vaults/index.js
+++ b/src/api/vaults/index.js
@@ -11,6 +11,17 @@ async function multichainVaults(ctx) {
   }
 }
 
+// async function vaultFees(ctx) {
+//   try {
+//     const multichainVaults = await getMultichainVaults();
+//     ctx.status = 200;
+//     ctx.body = [...multichainVaults];
+//   } catch (err) {
+//     console.error(err);
+//     ctx.status = 500;
+//   }
+// }
+
 module.exports = {
   multichainVaults,
 };

--- a/src/api/vaults/index.js
+++ b/src/api/vaults/index.js
@@ -1,4 +1,5 @@
 const { getMultichainVaults } = require('../stats/getMultichainVaults');
+const { getVaultFees } = require('./getVaultFees');
 
 async function multichainVaults(ctx) {
   try {
@@ -11,17 +12,18 @@ async function multichainVaults(ctx) {
   }
 }
 
-// async function vaultFees(ctx) {
-//   try {
-//     const multichainVaults = await getMultichainVaults();
-//     ctx.status = 200;
-//     ctx.body = [...multichainVaults];
-//   } catch (err) {
-//     console.error(err);
-//     ctx.status = 500;
-//   }
-// }
+async function vaultFees(ctx) {
+  try {
+    const vaultFees = await getVaultFees();
+    ctx.status = 200;
+    ctx.body = vaultFees;
+  } catch (err) {
+    console.error(err);
+    ctx.status = 500;
+  }
+}
 
 module.exports = {
   multichainVaults,
+  vaultFees,
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { initApyService } from './api/stats/getApys';
 import { initMooTokenPriceService } from './api/stats/getMooTokenPrices';
 import { initVaultService } from './api/stats/getMultichainVaults';
 import { initTvlService } from './api/stats/getTvl';
+import { initVaultFeeService } from './api/vaults/getVaultFees';
 
 require('./utils/redisHelper').initRedis();
 
@@ -41,6 +42,7 @@ const start = async () => {
   initApyService();
   initPriceService();
   initVaultService();
+  initVaultFeeService();
   initTvlService();
   initBifiBuyBackService();
   initMooTokenPriceService();

--- a/src/router.js
+++ b/src/router.js
@@ -33,6 +33,7 @@ router.get('/prices', price.tokenPrices);
 router.get('/mootokenprices', price.mooTokenPrices);
 
 router.get('/vaults', multichainVaults.multichainVaults);
+router.get('/fees', multichainVaults.vaultFees);
 
 router.get('/', noop);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,6 +267,21 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
+"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
+  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@ethersproject/abstract-provider@5.6.0", "@ethersproject/abstract-provider@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz#0c4ac7054650dbd9c476cf5907f588bbb6ef3061"
@@ -280,6 +295,19 @@
     "@ethersproject/transactions" "^5.6.0"
     "@ethersproject/web" "^5.6.0"
 
+"@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
+  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+
 "@ethersproject/abstract-signer@5.6.0", "@ethersproject/abstract-signer@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz#9cd7ae9211c2b123a3b29bf47aab17d4d016e3e7"
@@ -290,6 +318,17 @@
     "@ethersproject/bytes" "^5.6.0"
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
+
+"@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
+  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
 
 "@ethersproject/address@5.6.0", "@ethersproject/address@^5.0.4", "@ethersproject/address@^5.6.0":
   version "5.6.0"
@@ -302,12 +341,30 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/rlp" "^5.6.0"
 
+"@ethersproject/address@5.7.0", "@ethersproject/address@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
+  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+
 "@ethersproject/base64@5.6.0", "@ethersproject/base64@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.6.0.tgz#a12c4da2a6fb86d88563216b0282308fc15907c9"
   integrity sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
+
+"@ethersproject/base64@5.7.0", "@ethersproject/base64@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
+  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
 
 "@ethersproject/basex@5.6.0", "@ethersproject/basex@^5.6.0":
   version "5.6.0"
@@ -316,6 +373,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
+
+"@ethersproject/basex@5.7.0", "@ethersproject/basex@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.7.0.tgz#97034dc7e8938a8ca943ab20f8a5e492ece4020b"
+  integrity sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
 
 "@ethersproject/bignumber@5.6.0", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.6.0":
   version "5.6.0"
@@ -326,6 +391,15 @@
     "@ethersproject/logger" "^5.6.0"
     bn.js "^4.11.9"
 
+"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@5.6.1", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.6.0":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
@@ -333,12 +407,26 @@
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
+"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/constants@5.6.0", "@ethersproject/constants@^5.0.4", "@ethersproject/constants@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.6.0.tgz#55e3eb0918584d3acc0688e9958b0cedef297088"
   integrity sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==
   dependencies:
     "@ethersproject/bignumber" "^5.6.0"
+
+"@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
+  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
 
 "@ethersproject/contracts@5.6.0":
   version "5.6.0"
@@ -356,6 +444,22 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.0"
 
+"@ethersproject/contracts@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
+  integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+
 "@ethersproject/hash@5.6.0", "@ethersproject/hash@^5.0.4", "@ethersproject/hash@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
@@ -369,6 +473,21 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
+  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@ethersproject/hdnode@5.6.0", "@ethersproject/hdnode@^5.6.0":
   version "5.6.0"
@@ -387,6 +506,24 @@
     "@ethersproject/strings" "^5.6.0"
     "@ethersproject/transactions" "^5.6.0"
     "@ethersproject/wordlists" "^5.6.0"
+
+"@ethersproject/hdnode@5.7.0", "@ethersproject/hdnode@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.7.0.tgz#e627ddc6b466bc77aebf1a6b9e47405ca5aef9cf"
+  integrity sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wordlists" "^5.7.0"
 
 "@ethersproject/json-wallets@5.6.0", "@ethersproject/json-wallets@^5.6.0":
   version "5.6.0"
@@ -407,6 +544,25 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/json-wallets@5.7.0", "@ethersproject/json-wallets@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz#5e3355287b548c32b368d91014919ebebddd5360"
+  integrity sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hdnode" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/keccak256@5.6.0", "@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.0.tgz#fea4bb47dbf8f131c2e1774a1cecbfeb9d606459"
@@ -415,10 +571,23 @@
     "@ethersproject/bytes" "^5.6.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@5.7.0", "@ethersproject/keccak256@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
+  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.6.0", "@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
   integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
+
+"@ethersproject/logger@5.7.0", "@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
 "@ethersproject/networks@5.6.2", "@ethersproject/networks@^5.6.0":
   version "5.6.2"
@@ -426,6 +595,13 @@
   integrity sha512-9uEzaJY7j5wpYGTojGp8U89mSsgQLc40PCMJLMCnFXTs7nhBveZ0t7dbqWUNrepWTszDbFkYD6WlL8DKx5huHA==
   dependencies:
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/networks@5.7.0", "@ethersproject/networks@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.0.tgz#df72a392f1a63a57f87210515695a31a245845ad"
+  integrity sha512-MG6oHSQHd4ebvJrleEQQ4HhVu8Ichr0RDYEfHzsVAVjHNM+w36x9wp9r+hf1JstMXtseXDtkiVoARAG6M959AA==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/pbkdf2@5.6.0", "@ethersproject/pbkdf2@^5.6.0":
   version "5.6.0"
@@ -435,12 +611,27 @@
     "@ethersproject/bytes" "^5.6.0"
     "@ethersproject/sha2" "^5.6.0"
 
+"@ethersproject/pbkdf2@5.7.0", "@ethersproject/pbkdf2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz#d2267d0a1f6e123f3771007338c47cccd83d3102"
+  integrity sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+
 "@ethersproject/properties@5.6.0", "@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.6.0.tgz#38904651713bc6bdd5bdd1b0a4287ecda920fa04"
   integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
   dependencies:
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/properties@5.7.0", "@ethersproject/properties@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
+  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/providers@5.6.4":
   version "5.6.4"
@@ -467,6 +658,32 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.7.0", "@ethersproject/providers@^5.0.10":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.0.tgz#a885cfc7650a64385e7b03ac86fe9c2d4a9c2c63"
+  integrity sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.6.0", "@ethersproject/random@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.6.0.tgz#1505d1ab6a250e0ee92f436850fa3314b2cb5ae6"
@@ -474,6 +691,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/random@5.7.0", "@ethersproject/random@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
+  integrity sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/rlp@5.6.0", "@ethersproject/rlp@^5.6.0":
   version "5.6.0"
@@ -483,6 +708,14 @@
     "@ethersproject/bytes" "^5.6.0"
     "@ethersproject/logger" "^5.6.0"
 
+"@ethersproject/rlp@5.7.0", "@ethersproject/rlp@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
+  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/sha2@5.6.0", "@ethersproject/sha2@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.6.0.tgz#364c4c11cc753bda36f31f001628706ebadb64d9"
@@ -490,6 +723,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
     "@ethersproject/logger" "^5.6.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@5.7.0", "@ethersproject/sha2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
+  integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@5.6.0", "@ethersproject/signing-key@^5.6.0":
@@ -501,6 +743,18 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
+  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    bn.js "^5.2.1"
     elliptic "6.5.4"
     hash.js "1.1.7"
 
@@ -516,6 +770,18 @@
     "@ethersproject/sha2" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
+"@ethersproject/solidity@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
+  integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@ethersproject/strings@5.6.0", "@ethersproject/strings@^5.0.4", "@ethersproject/strings@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.6.0.tgz#9891b26709153d996bf1303d39a7f4bc047878fd"
@@ -524,6 +790,15 @@
     "@ethersproject/bytes" "^5.6.0"
     "@ethersproject/constants" "^5.6.0"
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/strings@5.7.0", "@ethersproject/strings@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
+  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/transactions@5.6.0", "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.6.0":
   version "5.6.0"
@@ -540,6 +815,21 @@
     "@ethersproject/rlp" "^5.6.0"
     "@ethersproject/signing-key" "^5.6.0"
 
+"@ethersproject/transactions@5.7.0", "@ethersproject/transactions@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
+  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+
 "@ethersproject/units@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.6.0.tgz#e5cbb1906988f5740254a21b9ded6bd51e826d9c"
@@ -548,6 +838,15 @@
     "@ethersproject/bignumber" "^5.6.0"
     "@ethersproject/constants" "^5.6.0"
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/units@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
+  integrity sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/wallet@5.6.0":
   version "5.6.0"
@@ -570,6 +869,27 @@
     "@ethersproject/transactions" "^5.6.0"
     "@ethersproject/wordlists" "^5.6.0"
 
+"@ethersproject/wallet@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
+  integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/hdnode" "^5.7.0"
+    "@ethersproject/json-wallets" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wordlists" "^5.7.0"
+
 "@ethersproject/web@5.6.0", "@ethersproject/web@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.6.0.tgz#4bf8b3cbc17055027e1a5dd3c357e37474eaaeb8"
@@ -581,6 +901,17 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
+"@ethersproject/web@5.7.0", "@ethersproject/web@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.0.tgz#40850c05260edad8b54827923bbad23d96aac0bc"
+  integrity sha512-ApHcbbj+muRASVDSCl/tgxaH2LBkRMEYfLOLVa0COipx0+nlu0QKet7U2lEg0vdkh8XRSLf2nd1f1Uk9SrVSGA==
+  dependencies:
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@ethersproject/wordlists@5.6.0", "@ethersproject/wordlists@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.6.0.tgz#79e62c5276e091d8575f6930ba01a29218ded032"
@@ -591,6 +922,17 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/wordlists@5.7.0", "@ethersproject/wordlists@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.7.0.tgz#8fb2c07185d68c3e09eb3bfd6e779ba2774627f5"
+  integrity sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@graphql-typed-document-node/core@^3.0.0":
   version "3.1.1"
@@ -1213,6 +1555,11 @@ bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 body-parser@1.19.2:
   version "1.19.2"
@@ -2367,6 +2714,14 @@ ethereum-cryptography@^0.1.3:
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
 
+ethereum-multicall@^2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/ethereum-multicall/-/ethereum-multicall-2.14.1.tgz#3fd11262336f1d4fadb52263df8c3318fd1b3433"
+  integrity sha512-uJ0B8E7Qu1PXdIWydoPJ9BD0tMGgcO7ruZruY7yo+1xZD7evKi/I19aX88xnYuoBhW9v5rx/CnACpD9ooVMFww==
+  dependencies:
+    "@ethersproject/providers" "^5.0.10"
+    ethers "^5.0.15"
+
 ethereumjs-util@^7.0.10, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz#a6885bcdd92045b06f596c7626c3e89ab3312458"
@@ -2392,6 +2747,42 @@ ethers@^4.0.47:
     setimmediate "1.0.4"
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
+
+ethers@^5.0.15:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.0.tgz#0055da174b9e076b242b8282638bc94e04b39835"
+  integrity sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==
+  dependencies:
+    "@ethersproject/abi" "5.7.0"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/address" "5.7.0"
+    "@ethersproject/base64" "5.7.0"
+    "@ethersproject/basex" "5.7.0"
+    "@ethersproject/bignumber" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/constants" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/hash" "5.7.0"
+    "@ethersproject/hdnode" "5.7.0"
+    "@ethersproject/json-wallets" "5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/logger" "5.7.0"
+    "@ethersproject/networks" "5.7.0"
+    "@ethersproject/pbkdf2" "5.7.0"
+    "@ethersproject/properties" "5.7.0"
+    "@ethersproject/providers" "5.7.0"
+    "@ethersproject/random" "5.7.0"
+    "@ethersproject/rlp" "5.7.0"
+    "@ethersproject/sha2" "5.7.0"
+    "@ethersproject/signing-key" "5.7.0"
+    "@ethersproject/solidity" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/units" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@ethersproject/web" "5.7.0"
+    "@ethersproject/wordlists" "5.7.0"
 
 ethers@^5.0.26, "ethersv5@npm:ethers@^5.0.32":
   name ethersv5

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,7 +2314,7 @@ eth-lib@^0.1.26:
     ws "^3.0.0"
     xhr-request-promise "^0.1.2"
 
-eth-multicall@^1.3.13:
+eth-multicall@^1.4:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/eth-multicall/-/eth-multicall-1.4.0.tgz#cfd913157260fbaca6522c0cdac5c7ba82afd13e"
   integrity sha512-qQEheqDy2cmVgCNIb/GWB+2vK4MB1DkyJYNEVtzR1mDWDcUZIdXdUAqr/QRequu0y2YTrre+ZPsFnS8tibGPDQ==


### PR DESCRIPTION
Fetch fees for all past vaults.

`eth-multicall` fails to support returning structs on multicalls, so if getFees is available, an individual RPC call must be done for that strat with a sleep delay so as to prevent spamming rpcs with calls.

Since namings changed quite a bit over time, a bunch of similarly named contracts must be called and each case of available vars must be considered to build fee data.

Update call is triggered every 10 minutes so as to pick up newer vaults, however updates to already existing fee data for a vault is triggered every 12 hours.

Added `ethereum-multicall` library to fill in where `eth-multicall` lacked