### PR TITLE
Update Jarvis/Fiat price fetch

### DIFF
--- a/packages/address-book/address-book/polygon/tokens/tokens.ts
+++ b/packages/address-book/address-book/polygon/tokens/tokens.ts
@@ -1484,6 +1484,17 @@ const _tokens = {
       'Giddy is an in-development app that simplifies sophisticated DeFi processes into a one-tap investing experience. The app will allow users to earn passive income with crypto assets using a multi-identity, self-custody, private key solution. The fully doxxed Giddy team focuses on security, compliance, and ease of use. Its mission is simple: to grow and adapt to the ever-changing regulatory landscape. This goal will keep investors and their funds within the bounds of current financial regulation. The Giddy token standard allows smart contracts to communicate effectively with compliant tokens. Its method involves encoding contract approval data into a meta-transaction, which removes the need for standalone and infinite contract approvals. GIDDY has a max capped supply of 1 billion tokens and began trading on April 6, 2022',
     logoURI: '',
   },
+  EURe: {
+    name: 'Monerium EURe emoney',
+    symbol: 'EURe',
+    address: '0x18ec0A6E18E5bc3784fDd3a3634b31245ab704F6',
+    chainId: 137,
+    decimals: 18,
+    logoURI: 'https://assets.coingecko.com/coins/images/23354/small/eur.png?1643926562',
+    website: 'https://monerium.com/',
+    description:
+      'EURe is a Euro stable-coin from Monerium. Monerium is the first company authorized to issue money on blockchains under European financial regulation. They have issued EUR, USD, GBP, and ISK as e-money tokens on Ethereum and EUR on Algorand. Monerium also operates a gateway for instant transfers of EUR between bank accounts and blockchain wallets/smart contracts.',
+  },
 } as const;
 
 export const tokens: ConstRecord<typeof _tokens, Token> = _tokens;

--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -8,6 +8,7 @@ import { fetchStargatePrices } from '../../utils/fetchStargatePrices';
 import { fetchbeFTMPrice } from '../../utils/fetchbeFTMPrice';
 import { fetchstDOTPrice } from '../../utils/fetchstDOTPrice';
 import { fetchCoinGeckoPrices } from '../../utils/fetchCoinGeckoPrices';
+import { fetchCurrencyPrices } from '../../utils/fetchCurrencyPrices';
 import { getKey, setKey } from '../../utils/redisHelper';
 
 import getNonAmmPrices from './getNonAmmPrices';
@@ -504,6 +505,10 @@ const coinGeckoCoins = [
   'rocket-pool-eth',
 ];
 
+const currencies = [
+  'cad',
+]
+
 const knownPrices = {
   BUSD: 1,
   USDT: 1,
@@ -545,6 +550,13 @@ const updateAmmPrices = async () => {
         alUSD: prices['alchemix-usd'],
         alETH: prices['ethereum'],
         rETH: prices['rocket-pool-eth'],
+      };
+    };
+
+    const currencyPrices = async () => {
+      const prices = await fetchCurrencyPrices(currencies);
+      return {
+        CAD: prices['cad'],
       };
     };
 
@@ -598,6 +610,7 @@ const updateAmmPrices = async () => {
         ...beTokenTokenPrice,
         ...stDOTTokenPrice,
         ...(await coinGeckoPrices()),
+        ...(await currencyPrices()),
       };
     });
 

--- a/src/api/stats/matic/getJarvisApys.js
+++ b/src/api/stats/matic/getJarvisApys.js
@@ -7,21 +7,22 @@ const fetchPrice = require('../../../utils/fetchPrice');
 const { getTotalLpStakedInUsd } = require('../../../utils/getTotalStakedInUsd');
 const getBlockTime = require('../../../utils/getBlockTime');
 import getApyBreakdown from '../common/getApyBreakdown';
-import { getCurveFactoryApy } from '../common/curve/getCurveApyData';
+import { getCurveBaseApys } from '../common/curve/getCurveApyData';
 import { getContractWithProvider } from '../../../utils/contractHelper';
 
 const DECIMALS = '1e18';
+const baseApyUrl = 'https://api.curve.fi/api/getSubgraphData/polygon';
+const tradingFee = 0.0004;
 
 const getJarvisApys = async () => {
   let promises = [];
+  const filteredPools = pools.filter(p => p.name != "jarvis-2eure"); // temp fix while trading APY is broken
+  const baseApys = await getCurveBaseApys(filteredPools, baseApyUrl);
   pools.forEach(pool => promises.push(getPoolApy(pool)));
   const farmAprs = await Promise.all(promises);
-  const tradingAprs = await getCurveFactoryApy(
-    pools[0].address,
-    'https://api.curve.fi/api/getFactoryAPYs-polygon'
-  );
+  const poolsMap = pools.map(p => ({ name: p.name, address: p.name, beefyFee: p.beefyFee }));
 
-  return getApyBreakdown(pools, tradingAprs, farmAprs, 0.004);
+  return getApyBreakdown(poolsMap, baseApys, farmAprs, tradingFee);
 };
 
 const getPoolApy = async pool => {
@@ -29,6 +30,8 @@ const getPoolApy = async pool => {
     getYearlyRewardsInUsd(pool.masterchef, pool.poolId, pool.rewardOracle, pool.rewardToken),
     getTotalLpStakedInUsd(pool.masterchef, pool, pool.chainId),
   ]);
+
+  //console.log(pool.name, yearlyRewardsInUsd.dividedBy(totalStakedInUsd).valueOf(), totalStakedInUsd.valueOf(), yearlyRewardsInUsd.valueOf());
 
   return yearlyRewardsInUsd.dividedBy(totalStakedInUsd);
 };

--- a/src/data/archive/oldDmmPools.json
+++ b/src/data/archive/oldDmmPools.json
@@ -1,5 +1,23 @@
 [
   {
+    "name": "kyber-usdc-jrt-nov22",
+    "address": "0x68Fd822a2Bda3dB31fFfA68089696ea4e55A9D36",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0x5eF12a086B8A61C0f11a72b36b5EF451FA17f1f1",
+      "oracle": "tokens",
+      "oracleId": "JRT-NOV22",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "kyber-usdc-jrt-sep22",
     "address": "0x2623D9a6cceb732f9e86125e107A18e7832B27e5",
     "decimals": "1e18",

--- a/src/data/matic/jarvisPools.json
+++ b/src/data/matic/jarvisPools.json
@@ -1,29 +1,45 @@
 [
   {
+    "name": "jarvis-2eure",
+    "pool": "0x2F3E9CA3bFf85B91D9fe6a9f3e8F9B1A6a4c3cF4",
+    "address": "0x2F3E9CA3bFf85B91D9fe6a9f3e8F9B1A6a4c3cF4",
+    "masterchef": "0xa0044b58b1de085845aeA7BD3256a00EAb4145a2",
+    "poolId": 3,
+    "chainId": 137,
+    "oracleId": "jEUR",
+    "rewardToken": "JRT-NOV22",
+    "rewardOracle": "tokens",
+    "token": "0x2F3E9CA3bFf85B91D9fe6a9f3e8F9B1A6a4c3cF4",
+    "baseApyKey": "2eur (EURe-f",
+    "beefyFee": 0.095
+  },
+  {
     "name": "jarvis-2eurp",
     "pool": "0x0f110c55EfE62c16D553A3d3464B77e1853d0e97",
     "address": "0x0f110c55EfE62c16D553A3d3464B77e1853d0e97",
-    "masterchef": "0x2BC39d179FAfC32B7796DDA3b936e491C87D245b",
+    "masterchef": "0xeA9871A9451c281cc1180100FC074D7F28402288",
     "poolId": 0,
     "chainId": 137,
     "oracleId": "jEUR",
-    "rewardToken": "JRT-MIMO-SEP22",
+    "rewardToken": "JRT-MIMO-NOV22",
     "rewardOracle": "lps",
     "token": "0x0f110c55EfE62c16D553A3d3464B77e1853d0e97",
-    "baseApyKey": "PARjEUR-f"
+    "baseApyKey": "PARjEUR-f",
+    "beefyFee": 0.095
   },
   {
     "name": "jarvis-2eurt",
     "pool": "0x2C3cc8e698890271c8141be9F6fD6243d56B39f1",
     "address": "0x2C3cc8e698890271c8141be9F6fD6243d56B39f1",
-    "masterchef": "0x2FAe83B3916e1467C970C113399ee91B31412bCD",
+    "masterchef": "0xa0044b58b1de085845aeA7BD3256a00EAb4145a2",
     "poolId": 4,
     "chainId": 137,
     "oracleId": "jEUR",
-    "rewardToken": "JRT-SEP22",
+    "rewardToken": "JRT-NOV22",
     "rewardOracle": "tokens",
     "token": "0x2C3cc8e698890271c8141be9F6fD6243d56B39f1",
-    "baseApyKey": "2eur EURT-f"
+    "baseApyKey": "2eur EURT-f",
+    "beefyFee": 0.095
   },
   {
     "name": "jarvis-2nzd",
@@ -42,53 +58,57 @@
     "name": "jarvis-2jpy2",
     "pool": "0xaA91CDD7abb47F821Cf07a2d38Cc8668DEAf1bdc",
     "address": "0xaA91CDD7abb47F821Cf07a2d38Cc8668DEAf1bdc",
-    "masterchef": "0x2FAe83B3916e1467C970C113399ee91B31412bCD",
+    "masterchef": "0xa0044b58b1de085845aeA7BD3256a00EAb4145a2",
     "poolId": 0,
     "chainId": 137,
     "oracleId": "JPYC",
-    "rewardToken": "JRT-SEP22",
+    "rewardToken": "JRT-NOV22",
     "rewardOracle": "tokens",
     "token": "0xaA91CDD7abb47F821Cf07a2d38Cc8668DEAf1bdc",
-    "baseApyKey": "2jpy-2-f"
+    "baseApyKey": "2jpy-2-f",
+    "beefyFee": 0.095
   },
   {
     "name": "jarvis-2eur",
     "pool": "0x2fFbCE9099cBed86984286A54e5932414aF4B717",
     "address": "0x2fFbCE9099cBed86984286A54e5932414aF4B717",
-    "masterchef": "0x9D5d2509C78f7dfEE7FD1b82a49c00Bc9dA70D28",
+    "masterchef": "0x7349Cc23B3A3E104ec2FA5A0BB29c8b022508779",
     "poolId": 0,
     "chainId": 137,
     "oracleId": "jEUR",
-    "rewardToken": "JRT-ANGLE-SEP22",
+    "rewardToken": "JRT-ANGLE-NOV22",
     "rewardOracle": "lps",
     "token": "0x2fFbCE9099cBed86984286A54e5932414aF4B717",
-    "baseApyKey": "agEURjEUR-f"
+    "baseApyKey": "agEURjEUR-f",
+    "beefyFee": 0.095
   },
   {
     "name": "jarvis-2sgd",
     "pool": "0xeF75E9C7097842AcC5D0869E1dB4e5fDdf4BFDDA",
     "address": "0xeF75E9C7097842AcC5D0869E1dB4e5fDdf4BFDDA",
-    "masterchef": "0x2FAe83B3916e1467C970C113399ee91B31412bCD",
+    "masterchef": "0xa0044b58b1de085845aeA7BD3256a00EAb4145a2",
     "poolId": 2,
     "chainId": 137,
     "oracleId": "XSGD",
-    "rewardToken": "JRT-SEP22",
+    "rewardToken": "JRT-NOV22",
     "rewardOracle": "tokens",
     "token": "0xeF75E9C7097842AcC5D0869E1dB4e5fDdf4BFDDA",
-    "baseApyKey": "jSGD+XSGD-f"
+    "baseApyKey": "jSGD+XSGD-f",
+    "beefyFee": 0.095
   },
   {
     "name": "jarvis-2cad",
     "pool": "0xA69b0D5c0C401BBA2d5162138613B5E38584F63F",
     "address": "0xA69b0D5c0C401BBA2d5162138613B5E38584F63F",
-    "masterchef": "0x2FAe83B3916e1467C970C113399ee91B31412bCD",
+    "masterchef": "0xa0044b58b1de085845aeA7BD3256a00EAb4145a2",
     "poolId": 1,
     "chainId": 137,
-    "oracleId": "CADC",
-    "rewardToken": "JRT-SEP22",
+    "oracleId": "CAD",
+    "rewardToken": "JRT-NOV22",
     "rewardOracle": "tokens",
     "token": "0xA69b0D5c0C401BBA2d5162138613B5E38584F63F",
-    "baseApyKey": "jCAD+CADC-f"
+    "baseApyKey": "jCAD+CADC-f",
+    "beefyFee": 0.095
   },
   {
     "name": "jarvis-2jpy",

--- a/src/data/matic/jarvisRewardPool.json
+++ b/src/data/matic/jarvisRewardPool.json
@@ -1,5 +1,41 @@
 [
   {
+    "name": "kyber-2eurp-jrt-mimo-nov22",
+    "address": "0x946bE3eCAebaA3fe2eBb73864ab555A8cfdF49Fd",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x0f110c55EfE62c16D553A3d3464B77e1853d0e97",
+      "oracle": "tokens",
+      "oracleId": "jarvis-2eurp",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x4Fd52587194a0bfd3AC5b8096D15e1a7230bA2eb",
+      "oracle": "tokens",
+      "oracleId": "JRT-MIMO-NOV22",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "kyber-2eur-jrt-angle-nov22",
+    "address": "0x4D44f653B885fbddF486a71508Afd63071ca1A6E",
+    "decimals": "1e18",
+    "chainId": 137,
+    "lp0": {
+      "address": "0x2fFbCE9099cBed86984286A54e5932414aF4B717",
+      "oracle": "tokens",
+      "oracleId": "jarvis-2eur",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x63B87304fc9889Ce7356396ea959aA64850a52E7",
+      "oracle": "tokens",
+      "oracleId": "JRT-ANGLE-NOV22",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "kyber-2eur-jrt-angle-sep22",
     "address": "0x8c2fe36E51657385d3091E92FbACb79263867F16",
     "decimals": "1e18",

--- a/src/utils/fetchCurrencyPrices.js
+++ b/src/utils/fetchCurrencyPrices.js
@@ -1,0 +1,21 @@
+const fetch = require('node-fetch');
+
+const fetchCurrencyPrices = async currencies => {
+  if (!currencies) return {};
+  const ids = currencies.join(',');
+  const url = `https://api.coingecko.com/api/v3/simple/price?ids=usd-coin&vs_currencies=${currencies}`;
+  let prices = {};
+  try {
+    const data = await fetch(url).then(res => res.json());
+    Object.keys(data["usd-coin"]).forEach(currencies => {
+      const price = Number(data["usd-coin"][currencies]);
+      const inversePrice = price > 0 ? 1/price : 0;
+      prices = { ...prices, ...{ [currencies]: inversePrice } };
+    });
+  } catch (e) {
+    console.error('> fetchCurrencyPrices', e);
+  }
+  return prices;
+};
+
+module.exports = { fetchCurrencyPrices };


### PR DESCRIPTION
Added logic for fetching fiat currencies from CoinGecko as no reliable oracle for CAD could be sourced simply. CoinGecko has CADC as 70% over the actual value intermittenly.