### PR TITLE
Add VVS USDC-BUSD

### DIFF
--- a/packages/address-book/address-book/cronos/tokens/tokens.ts
+++ b/packages/address-book/address-book/cronos/tokens/tokens.ts
@@ -285,12 +285,24 @@ const _tokens = {
   BUSD: {
     name: 'BUSD Token',
     symbol: 'BUSD',
-    address: '0x6aB6d61428fde76768D7b45D8BFeec19c6eF91A8',
+    address: '0xC74D59A548ecf7fc1754bb7810D716E9Ac3e3AE5',
     chainId: 25,
     decimals: 18,
     website: 'https://www.binance.com/en/busd',
     description:
       'Binance USD (BUSD) is a 1:1 USD-backed stable coin issued by Binance (in partnership with Paxos), Approved and regulated by the New York State Department of Financial Services (NYDFS), The BUSD Monthly Audit Report can be viewed from the official website.',
+    logoURI:
+      'https://app.cronaswap.org/images/tokens/0x6aB6d61428fde76768D7b45D8BFeec19c6eF91A8.svg',
+  },
+  BUSDb: {
+    name: 'BUSD Token (Multichain)',
+    symbol: 'BUSD',
+    address: '0x6aB6d61428fde76768D7b45D8BFeec19c6eF91A8',
+    chainId: 25,
+    decimals: 18,
+    website: 'https://www.binance.com/en/busd',
+    description:
+      'Multichain bridged Binance USD (BUSD) is a 1:1 USD-backed stable coin issued by Binance (in partnership with Paxos), Approved and regulated by the New York State Department of Financial Services (NYDFS), The BUSD Monthly Audit Report can be viewed from the official website.',
     logoURI:
       'https://app.cronaswap.org/images/tokens/0x6aB6d61428fde76768D7b45D8BFeec19c6eF91A8.svg',
   },

--- a/src/data/cronos/vvsLpPools.json
+++ b/src/data/cronos/vvsLpPools.json
@@ -302,5 +302,24 @@
       "oracleId": "USDC",
       "decimals": "1e6"
     }
+  },
+  {
+    "name": "vvs-usdc-busd",
+    "address": "0x792Df67276615d6E85e36497c4514b7b102Af4A9",
+    "decimals": "1e18",
+    "poolId": 33,
+    "chainId": 25,
+    "lp0": {
+      "address": "0xc21223249CA28397B4B6541dfFaEcC539BfF0c59",
+      "oracle": "tokens",
+      "oracleId": "USDC",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0xC74D59A548ecf7fc1754bb7810D716E9Ac3e3AE5",
+      "oracle": "tokens",
+      "oracleId": "BUSD",
+      "decimals": "1e18"
+    }
   }
 ]


### PR DESCRIPTION
Updating contract address for BUSD token on Cronos to match official Binance issue.  Previous "BUSD" was from multichain.  Kept multichain version as BUSDb (bridged).