### PR TITLE
Add API endpoint for chain configuration

### DIFF
--- a/src/api/config/getConfig.ts
+++ b/src/api/config/getConfig.ts
@@ -1,0 +1,53 @@
+import { addressBook } from '../../../packages/address-book/address-book';
+
+const configsByChain: Record<string, Record<string, Config>> = {};
+
+interface Config {
+  devMultisig: string;
+  treasuryMultisig: string;
+  strategyOwner: string;
+  vaultOwner: string;
+  keeper: string;
+  treasurer: string;
+  launchpoolOwner: string;
+  rewardPool: string;
+  treasury: string;
+  beefyFeeRecipient: string;
+  bifiMaxiStrategy: string;
+  voter: string;
+  beefyFeeConfig: string;
+}
+
+export const initConfigService = () => {
+  Object.keys(addressBook).forEach(chain => {
+    configsByChain[chain] = {};
+
+    const config = addressBook[chain].platforms.beefyfinance;
+    // Prune ab fields
+    configsByChain[chain] = {
+      devMultisig: config.devMultisig,
+      treasuryMultisig: config.treasuryMultisig,
+      strategyOwner: config.strategyOwner,
+      vaultOwner: config.vaultOwner,
+      keeper: config.keeper,
+      treasurer: config.treasurer,
+      launchpoolOwner: config.launchpoolOwner,
+      rewardPool: config.rewardPool,
+      treasury: config.treasury,
+      beefyFeeRecipient: config.beefyFeeRecipient,
+      bifiMaxiStrategy: config.bifiMaxiStrategy,
+      voter: config.voter,
+      beefyFeeConfig: config.beefyFeeConfig,
+    };
+  });
+
+  console.log('> Configs initialized');
+};
+
+export const getAllConfigs = () => {
+  return configsByChain;
+};
+
+export const getSingleChainConfig = (chain: string) => {
+  return configsByChain[chain] ?? [];
+};

--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -1,0 +1,13 @@
+import { getAllConfigs, getSingleChainConfig } from './getConfig';
+
+export const getConfigs = ctx => {
+  const allConfigs = getAllConfigs();
+  ctx.status = 200;
+  ctx.body = allConfigs;
+};
+
+export const getChainConfig = ctx => {
+  const chainConfigs = getSingleChainConfig(ctx.params.chainId);
+  ctx.status = 200;
+  ctx.body = chainConfigs;
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { initMooTokenPriceService } from './api/stats/getMooTokenPrices';
 import { initVaultService } from './api/stats/getMultichainVaults';
 import { initTvlService } from './api/stats/getTvl';
 import { initTokenService } from './api/tokens/getTokens';
+import { initConfigService } from './api/config/getConfig';
 import { initVaultFeeService } from './api/vaults/getVaultFees';
 
 require('./utils/redisHelper').initRedis();
@@ -50,6 +51,7 @@ const start = async () => {
   initBifiBuyBackService();
   initMooTokenPriceService();
   initTokenService();
+  initConfigService();
   app.listen(port);
   console.log(`> beefy-api running! (:${port})`);
 };

--- a/src/router.js
+++ b/src/router.js
@@ -14,6 +14,7 @@ const multichainVaults = require('./api/vaults');
 const { boosts, chainBoosts } = require('./api/boosts');
 const { bifibuyback } = require('./api/stats/bifibuyback/index');
 const { getTokens, getChainTokens } = require('./api/tokens');
+const { getConfigs, getChainConfig } = require('./api/config');
 
 router.get('/apy', stats.apy);
 router.get('/apy/breakdown', stats.apyBreakdowns);
@@ -44,6 +45,9 @@ router.get('/boosts/:chainId', chainBoosts);
 
 router.get('/tokens', getTokens);
 router.get('/tokens/:chainId', getChainTokens);
+
+router.get('/config', getConfigs);
+router.get('/config/:chainId', getChainConfig);
 
 router.get('/', noop);
 


### PR DESCRIPTION
This provides an automated endpoint for some chain configuration data. This will improve automation and agility as data changes.

This was tested locally and appears to work as intended. The code was largely copied from @seguido, so I defer any praise and/or blame to him!