### PR TITLE
Fix png-qi-wavax + Calculate LP breakdown after all prices have resolved

### DIFF
--- a/src/data/avax/pangolinv2LpPools.json
+++ b/src/data/avax/pangolinv2LpPools.json
@@ -274,7 +274,7 @@
     "lp0": {
       "address": "0x8729438EB15e2C8B576fCc6AeCdA6A148776C0F5",
       "oracle": "tokens",
-      "oracleId": "QI",
+      "oracleId": "aQI",
       "decimals": "1e18"
     },
     "lp1": {

--- a/src/utils/fetchAmmPrices.js
+++ b/src/utils/fetchAmmPrices.js
@@ -37,7 +37,6 @@ const sortByKeys = o => {
 const calcTokenPrice = (knownPrice, knownToken, unknownToken) => {
   const valuation = knownToken.balance.dividedBy(knownToken.decimals).multipliedBy(knownPrice);
   const price = valuation.multipliedBy(unknownToken.decimals).dividedBy(unknownToken.balance);
-  const weight = knownToken.balance.plus(unknownToken.balance).toNumber();
 
   return {
     price: price.toNumber(),
@@ -134,14 +133,17 @@ const fetchAmmPrices = async (pools, knownPrices) => {
           prices[unknownToken.oracleId] = price;
           weights[unknownToken.oracleId] = weight;
         }
-        const lpData = calcLpPrice(pool, prices);
-        lps[pool.name] = lpData.price;
-        breakdown[pool.name] = lpData;
 
         unsolved.splice(i, 1);
         solving = true;
       }
     }
+  }
+
+  for (const pool of pools) {
+    const lpData = calcLpPrice(pool, prices);
+    lps[pool.name] = lpData.price;
+    breakdown[pool.name] = lpData;
   }
 
   return {

--- a/src/utils/fetchDmmPrices.ts
+++ b/src/utils/fetchDmmPrices.ts
@@ -17,7 +17,6 @@ const sortByKeys = o => {
 const calcTokenPrice = (knownPrice, knownToken, unknownToken) => {
   const valuation = knownToken.virtualBal.dividedBy(knownToken.decimals).multipliedBy(knownPrice);
   const price = valuation.multipliedBy(unknownToken.decimals).dividedBy(unknownToken.virtualBal);
-  const weight = knownToken.virtualBal.plus(unknownToken.virtualBal).toNumber();
 
   return {
     price: price.toNumber(),
@@ -133,14 +132,16 @@ export const fetchDmmPrices = async (pools, knownPrices) => {
           weights[unknownToken.oracleId] = weight;
         }
 
-        const lpData = calcLpPrice(pool, prices);
-        lps[pool.name] = lpData.price;
-        breakdown[pool.name] = lpData;
-
         unsolved.splice(i, 1);
         solving = true;
       }
     }
+  }
+
+  for (const pool of pools) {
+    const lpData = calcLpPrice(pool, prices);
+    lps[pool.name] = lpData.price;
+    breakdown[pool.name] = lpData;
   }
 
   return {


### PR DESCRIPTION
png-qi-wavax lp0 oracleId was set to `QI` (QiDao) instead of `aQI` (BENQI) giving wrong price of QI
this in turn set the price of AVAX to 400+ instead of 12.8 for some of the pools lp data/price calculation.

@seguido I've also moved the lp price/data calculations to happen after all prices have resolved (rather than the first time the pool is used to resolve a price); which should result in the most accurate prices.