### PR TITLE
Add snapshot endpoint to fetch latest proposal

### DIFF
--- a/src/api/snapshot/getLatestProposal.ts
+++ b/src/api/snapshot/getLatestProposal.ts
@@ -1,0 +1,164 @@
+import { getKey, setKey } from '../../utils/redisHelper';
+import {
+  Cached,
+  CachedNoOpenProposal,
+  CachedProposal,
+  CachedSpace,
+  isCachedNoOpenProposal,
+  isCachedProposal,
+  isCachedSpace,
+  Proposal,
+} from './types';
+import { getSnapshotApi } from './getSnapshotApi';
+import { isBefore, sub } from 'date-fns';
+
+const SPACE_ID = 'beefydao.eth';
+const CACHE_KEY_SPACE = 'gov_space';
+const CACHE_KEY_PROPOSAL = 'gov_proposal';
+const MAX_SPACE_AGE_MINS = 24 * 60; // minutes
+const MAX_PROPOSAL_AGE_MINS = 15; // minutes
+const ALLOW_FROM_ADMINS: boolean = true;
+const ALLOW_FROM_MEMBERS: boolean = true;
+const ALLOW_FROM_LIST: boolean = true;
+const ALLOW_FROM_ANYONE: boolean = false;
+
+const ALLOW_LIST: string[] = ['0x280A53cBf252F1B5F6Bde7471299c94Ec566a7C8'];
+
+let cachedSpace: CachedSpace | null = null;
+let cachedProposal: CachedProposal | CachedNoOpenProposal | null = null;
+
+async function getCachedSpace(): Promise<CachedSpace | null> {
+  const value = await getKey(CACHE_KEY_SPACE);
+  return isCachedSpace(value) ? value : null;
+}
+
+async function getCachedProposal(): Promise<CachedProposal | CachedNoOpenProposal | null> {
+  const value = await getKey(CACHE_KEY_PROPOSAL);
+  return isCachedProposal(value) || isCachedNoOpenProposal(value) ? value : null;
+}
+
+function timestamp<T extends {}>(obj: T): Cached<T> {
+  return {
+    ...obj,
+    updatedAt: Date.now(),
+  };
+}
+
+function isStale<T extends Cached<{}>>(obj: T, maxMinutes: number): boolean {
+  const maxAge = sub(new Date(), { minutes: maxMinutes });
+  return isBefore(obj.updatedAt, maxAge);
+}
+
+function hasProposalEnded(proposal: CachedProposal): boolean {
+  return isBefore(proposal.end * 1000, new Date());
+}
+
+async function updateSpace() {
+  const api = await getSnapshotApi();
+  const space = await api.getSpace(SPACE_ID);
+
+  console.debug('[snapshot]', 'updated space:', space);
+
+  cachedSpace = timestamp(space);
+
+  await setKey(CACHE_KEY_SPACE, cachedSpace);
+}
+
+function getValidAuthors() {
+  const authors = [];
+
+  if (ALLOW_FROM_ADMINS) {
+    authors.push(...cachedSpace.admins);
+  }
+
+  if (ALLOW_FROM_MEMBERS) {
+    authors.push(...cachedSpace.members);
+  }
+
+  if (ALLOW_FROM_LIST && ALLOW_LIST.length) {
+    authors.push(...ALLOW_LIST);
+  }
+
+  return authors.map(address => address.toLowerCase());
+}
+
+async function setProposal(proposal: Proposal) {
+  console.debug('[snapshot]', 'updated proposal:', proposal);
+
+  cachedProposal = timestamp(proposal);
+
+  await setKey(CACHE_KEY_PROPOSAL, cachedProposal);
+}
+
+async function setNoProposal() {
+  console.debug('updated proposal: no valid proposals active');
+
+  cachedProposal = timestamp({
+    id: 'no-open-proposal',
+  });
+
+  await setKey(CACHE_KEY_PROPOSAL, cachedProposal);
+}
+
+async function updateProposal() {
+  if (!cachedSpace) {
+    console.error('Can not update proposal without updating space first.');
+    return;
+  }
+
+  const api = await getSnapshotApi();
+  const proposals = await api.getProposals(SPACE_ID, 'open', ALLOW_FROM_ANYONE ? 1 : 10, 0);
+
+  console.debug('[snapshot]', proposals);
+
+  if (proposals.length) {
+    if (ALLOW_FROM_ANYONE) {
+      await setProposal(proposals[0]);
+    } else {
+      const authors = getValidAuthors();
+      const proposal = proposals.find(p => authors.includes(p.author.toLowerCase()));
+      if (proposal) {
+        await setProposal(proposal);
+      } else {
+        await setNoProposal();
+      }
+    }
+  } else {
+    await setNoProposal();
+  }
+}
+
+async function updateSpaceIfNeeded() {
+  if (!cachedSpace || isStale(cachedSpace, MAX_SPACE_AGE_MINS)) {
+    await updateSpace();
+  }
+}
+
+async function updateProposalIfNeeded() {
+  if (!cachedProposal || isStale(cachedProposal, MAX_PROPOSAL_AGE_MINS)) {
+    await updateProposal();
+  }
+}
+
+async function updateIfNeeded() {
+  await updateSpaceIfNeeded();
+  await updateProposalIfNeeded();
+}
+
+export async function initProposalsService() {
+  [cachedSpace, cachedProposal] = await Promise.all([getCachedSpace(), getCachedProposal()]);
+
+  await updateIfNeeded();
+
+  setInterval(() => {
+    updateIfNeeded().catch(err => console.error(err));
+  }, MAX_PROPOSAL_AGE_MINS * 60 * 1000 + 1000);
+}
+
+export function getLatestProposal(): CachedProposal | null {
+  if (isCachedProposal(cachedProposal) && !hasProposalEnded(cachedProposal)) {
+    return cachedProposal;
+  }
+
+  return null;
+}

--- a/src/api/snapshot/getSnapshotApi.ts
+++ b/src/api/snapshot/getSnapshotApi.ts
@@ -1,0 +1,80 @@
+import { ApolloClient, gql, NormalizedCacheObject } from '@apollo/client/core';
+import { client } from '../../apollo/client';
+import { Proposal, Space } from './types';
+
+// https://docs.snapshot.org/graphql-api#space
+const QUERY_SPACE = gql`
+  query Space($spaceId: String!) {
+    space(id: $spaceId) {
+      id
+      admins
+      members
+    }
+  }
+`;
+
+// https://docs.snapshot.org/graphql-api#proposal
+const QUERY_PROPOSALS = gql`
+  query Space($spaceId: String!, $state: String!, $first: Int!, $skip: Int!) {
+    proposals(
+      first: $first
+      skip: $skip
+      where: { space: $spaceId, state: $state }
+      orderBy: "created"
+      orderDirection: desc
+    ) {
+      id
+      title
+      end
+      author
+    }
+  }
+`;
+
+class SnapshotApi {
+  protected client: ApolloClient<NormalizedCacheObject>;
+
+  constructor() {
+    this.client = client('https://hub.snapshot.org/graphql');
+  }
+
+  async getSpace(spaceId: string): Promise<Space> {
+    const result = await this.client.query<{ space: Space }>({
+      query: QUERY_SPACE,
+      variables: {
+        spaceId,
+      },
+    });
+
+    return result.data.space;
+  }
+
+  async getProposals(
+    spaceId: string,
+    state: 'open' | 'closed' = 'open',
+    first: number = 10,
+    skip: number = 0
+  ): Promise<Proposal[]> {
+    const result = await this.client.query<{ proposals: Proposal[] }>({
+      query: QUERY_PROPOSALS,
+      variables: {
+        spaceId,
+        state: state || 'open',
+        first: first || 10,
+        skip: skip || 0,
+      },
+    });
+
+    return result.data.proposals;
+  }
+}
+
+let instance: SnapshotApi | null = null;
+
+export async function getSnapshotApi(): Promise<SnapshotApi> {
+  if (!instance) {
+    instance = new SnapshotApi();
+  }
+
+  return instance;
+}

--- a/src/api/snapshot/index.ts
+++ b/src/api/snapshot/index.ts
@@ -1,0 +1,16 @@
+import { getLatestProposal } from './getLatestProposal';
+import Koa from 'koa';
+
+// latest proposal to display on app
+function latest(ctx: Koa.Context) {
+  try {
+    const proposal = getLatestProposal();
+    ctx.status = 200;
+    ctx.body = proposal;
+  } catch (err) {
+    console.error(err);
+    ctx.status = 500;
+  }
+}
+
+export { latest };

--- a/src/api/snapshot/types.ts
+++ b/src/api/snapshot/types.ts
@@ -1,0 +1,46 @@
+export type Space = {
+  id: string;
+  members: string;
+  admins: string;
+};
+
+export type Proposal = {
+  id: string;
+  title: string;
+  end: number;
+  author: string;
+};
+
+export type NoOpenProposal = {
+  id: 'no-open-proposal';
+};
+
+export type Cached<T extends {}> = T & {
+  updatedAt: number;
+};
+
+export type CachedSpace = Cached<Space>;
+export type CachedProposal = Cached<Proposal>;
+export type CachedNoOpenProposal = Cached<NoOpenProposal>;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value && typeof value === 'object';
+}
+
+export function isCachedSpace(space: unknown): space is CachedSpace {
+  return isObject(space) && !!space.id && !!space.members && !!space.admins && !!space.updatedAt;
+}
+
+export function isCachedProposal(proposal: unknown): proposal is CachedProposal {
+  return (
+    isObject(proposal) &&
+    !!proposal.id &&
+    !!proposal.title &&
+    !!proposal.end &&
+    !!proposal.updatedAt
+  );
+}
+
+export function isCachedNoOpenProposal(obj: unknown): obj is CachedNoOpenProposal {
+  return isObject(obj) && obj.id === 'no-open-proposal' && !!obj.updatedAt;
+}

--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -12,7 +12,7 @@ import ApolloLinkTimeout from 'apollo-link-timeout';
 const APOLLO_TIMEOUT = process.env.APOLLO_TIMEOUT ? parseInt(process.env.APOLLO_TIMEOUT) : 30_000;
 const timeoutLink: ApolloLink = new ApolloLinkTimeout(APOLLO_TIMEOUT);
 
-function client(url: string) {
+export function client(url: string) {
   const httpLink = createHttpLink({ uri: url, fetch });
   const timeoutHttpLink = timeoutLink.concat(httpLink as any as ApolloLink | RequestHandler);
   return new ApolloClient({

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import { initTvlService } from './api/stats/getTvl';
 import { initTokenService } from './api/tokens/getTokens';
 import { initConfigService } from './api/config/getConfig';
 import { initVaultFeeService } from './api/vaults/getVaultFees';
+import { initProposalsService } from './api/snapshot/getLatestProposal';
 
 require('./utils/redisHelper').initRedis();
 
@@ -52,6 +53,7 @@ const start = async () => {
   initMooTokenPriceService();
   initTokenService();
   initConfigService();
+  initProposalsService();
   app.listen(port);
   console.log(`> beefy-api running! (:${port})`);
 };

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,7 @@ const gov = require('./api/stats/gov');
 const cmc = require('./api/cmc');
 const tvl = require('./api/tvl');
 const multichainVaults = require('./api/vaults');
+const snapshot = require('./api/snapshot');
 const { boosts, chainBoosts } = require('./api/boosts');
 const { bifibuyback } = require('./api/stats/bifibuyback/index');
 const { getTokens, getChainTokens } = require('./api/tokens');
@@ -48,6 +49,8 @@ router.get('/tokens/:chainId', getChainTokens);
 
 router.get('/config', getConfigs);
 router.get('/config/:chainId', getChainConfig);
+
+router.get('/snapshot/latest', snapshot.latest);
 
 router.get('/', noop);
 


### PR DESCRIPTION
Adds `/snapshot/latest` which returns the latest (1) proposal.

As this is intended to be used in UI to automatically show new proposals, only proposals from allow-listed authors are returned.
This is configurable using the follow variables.
('admins' and 'members' refer to the admins and authors defined in the snapshot space.)

```ts
const ALLOW_FROM_ADMINS: boolean = true;
const ALLOW_FROM_MEMBERS: boolean = true;
const ALLOW_FROM_LIST: boolean = true;
const ALLOW_FROM_ANYONE: boolean = false;
const ALLOW_LIST: string[] = ['0x280A53cBf252F1B5F6Bde7471299c94Ec566a7C8'];
```

Example response:
```json
{
  "id": "0x90e15a8ba3cfa8b9539b6a428130ae2987d77336ed6f9005f198b744552bc081",
  "title": "[BIP:58] Adopt Governance Guidelines",
  "end": 1670018400,
  "author": "0x280A53cBf252F1B5F6Bde7471299c94Ec566a7C8",
  "updatedAt": 1669567869710
}
```
Note: `null` be be returned if there are no active proposals/no active proposals whose author is allow-listed.