### PR TITLE
add optional oracleId to tokens in addressbook, and add it for FISH

### DIFF
--- a/packages/address-book/address-book/arbitrum/tokens/tokens.ts
+++ b/packages/address-book/address-book/arbitrum/tokens/tokens.ts
@@ -283,6 +283,7 @@ const _tokens = {
     decimals: 18,
     website: 'https://swapfish.fi/',
     description: 'Brand new decentralized platform bringing you fresh fishing farms and more.',
+    oracleId: 'SWAPFISH',
   },
   GMX: {
     name: 'GMX',

--- a/packages/address-book/types/token.ts
+++ b/packages/address-book/types/token.ts
@@ -6,5 +6,6 @@ interface Token {
   decimals: number;
   logoURI?: string;
   documentation?: string;
+  oracleId?: string;
 }
 export default Token;


### PR DESCRIPTION
This would allow tokens with the same name to be displayed their names in the app whilst using a different price oracleId.

Current situation:
FISH (polycat - polygon) and FISH (swapfish - arbitrum) have identical names and the app uses their names as the oracleId for them.

However the oracleId for fish (swapfish) is SWAPFISH, being able to set this in the ab would allow the app to update the oracleId accordingly whilst keeping FISH as name.