### PR TITLE
Ignore cached assets not found on treasury report

### DIFF
--- a/src/api/treasury/getTreasury.ts
+++ b/src/api/treasury/getTreasury.ts
@@ -244,6 +244,9 @@ const buildTreasuryReport = async () => {
 
     for (const assetBalance of Object.values(chainBalancesByAddress)) {
       const treasuryAsset = assetsByChain[chain][assetBalance.address];
+
+      if (treasuryAsset === undefined) continue; //cached asset hasn't been deleted yet
+
       const price = await fetchPrice({
         oracle: treasuryAsset.oracleType,
         id: treasuryAsset.oracleId,


### PR DESCRIPTION
The asset balances are cached for quick recovery on API restarts. However all assets aren't and are instead updated on load. If a vault/asset is deleted from ab/app, the balance cache would have the address+balance for it but we wouldn't have info on the asset details