### PR TITLE
Treasury cache cleanup

### DIFF
--- a/packages/address-book/address-book/metis/tokens/tokens.ts
+++ b/packages/address-book/address-book/metis/tokens/tokens.ts
@@ -77,6 +77,7 @@ const _tokens = {
     documentation: 'https://developers.circle.com/docs',
     description:
       'USDC is a fully collateralized US dollar stablecoin. USDC is issued by regulated financial institutions, backed by fully reserved assets, redeemable on a 1:1 basis for US dollars.',
+    oracleId: 'USDC',
   },
   mDAI: {
     name: 'Dai Stablecoin',

--- a/packages/address-book/address-book/metis/tokens/tokens.ts
+++ b/packages/address-book/address-book/metis/tokens/tokens.ts
@@ -212,7 +212,7 @@ const _tokens = {
   'BIFI-METIS LP': {
     name: 'BIFI-METIS LP',
     symbol: 'BIFI-METIS LP',
-    address: '0x0f9602B7E7146a9BaE16dB948281BebDb7C2D095',
+    address: '0x89D433e8cCC871B3f12EA17b651ff3633DFb5DC0',
     chainId: 1088,
     decimals: 18,
     logoURI: '',


### PR DESCRIPTION
- Ignore WMETIS from treasury balance report (same as celo, WMETIS and METIS are in fact the same token so balances would appear twice)
- Clear old balance cached values when all balance requests return successfully, purging old and deprecated assets
- Fix bifi-metis lp address in addressbook