### PR TITLE
Boost APR endpoint

### DIFF
--- a/src/api/boosts/getBoosts.ts
+++ b/src/api/boosts/getBoosts.ts
@@ -1,16 +1,17 @@
 import { MULTICHAIN_ENDPOINTS } from '../../constants';
 import { getKey, setKey } from '../../utils/redisHelper';
 import { getBoostPeriodFinish, getBoosts } from './fetchBoostData';
+import { Boost } from './types';
 
 const REDIS_KEY = 'BOOSTS_BY_CHAIN';
 
 const INIT_DELAY = 4 * 1000;
 const REFRESH_INTERVAL = 5 * 60 * 1000;
 
-let boostsByChain: Record<string, any[]> = {};
-let allBoosts = [];
+let boostsByChain: Record<string, Boost[]> = {};
+let allBoosts: Boost[] = [];
 
-export const getAllBosts = () => {
+export const getAllBoosts = () => {
   return allBoosts;
 };
 
@@ -48,7 +49,7 @@ const updateBoosts = async () => {
 
 const updateChainBoosts = async (chain: string, appUrlName: string) => {
   try {
-    let chainBoosts = await getBoosts(appUrlName);
+    let chainBoosts: Boost[] = await getBoosts(appUrlName);
     chainBoosts.forEach(boost => (boost.chain = chain));
     chainBoosts = await getBoostPeriodFinish(chain, chainBoosts);
     boostsByChain[chain] = chainBoosts;

--- a/src/api/boosts/index.ts
+++ b/src/api/boosts/index.ts
@@ -1,8 +1,8 @@
-import { getAllBosts, getChainBoosts } from './getBoosts';
+import { getAllBoosts, getChainBoosts } from './getBoosts';
 
 export const boosts = async (ctx: any) => {
   try {
-    const allBoosts = getAllBosts();
+    const allBoosts = getAllBoosts();
     ctx.status = 200;
     ctx.body = [...allBoosts];
   } catch (err) {

--- a/src/api/boosts/types.ts
+++ b/src/api/boosts/types.ts
@@ -1,0 +1,19 @@
+export type Boost = {
+  id: string;
+  poolId: string;
+  name: string;
+  assets: string[];
+  tokenAddress: string;
+  earnedToken: string;
+  earnedTokenDecimals: number;
+  earnedTokenAddress: string;
+  earnContractAddress: string;
+  earnedOracle: 'tokens' | 'lps';
+  earnedOracleId: string;
+  partnership: boolean;
+  status: 'active' | 'prestake' | 'closed';
+  isMooStaked: boolean;
+  partners: string[];
+  chain: string;
+  periodFinish: number;
+};

--- a/src/api/stats/getApys.js
+++ b/src/api/stats/getApys.js
@@ -18,12 +18,15 @@ const { getOptimismApys } = require('./optimism');
 const { getKavaApys } = require('./kava');
 const { getEthereumApys } = require('./ethereum');
 const { getKey, setKey } = require('../../utils/redisHelper');
+const { fetchBoostAprs } = require('./getBoostAprs');
 
 const INIT_DELAY = process.env.INIT_DELAY || 60 * 1000;
 var REFRESH_INTERVAL = 15 * 60 * 1000;
+const BOOST_REFRESH_INTERVAL = 2 * 60 * 1000;
 
 let apys = {};
 let apyBreakdowns = {};
+let boostAprs = {};
 
 const getApys = () => {
   return {
@@ -32,9 +35,11 @@ const getApys = () => {
   };
 };
 
+const getBoostAprs = () => boostAprs;
+
 const updateApys = async () => {
   console.log('> updating apys');
-
+  const start = Date.now();
   try {
     const results = await Promise.allSettled([
       getMaticApys(),
@@ -88,7 +93,7 @@ const updateApys = async () => {
       apyBreakdowns = { ...apyBreakdowns, ...mappedApyBreakdownValues };
     }
 
-    console.log('> updated apys');
+    console.log(`> updated apys (${(Date.now() - start) / 1000}s)`);
     await saveToRedis();
   } catch (err) {
     console.error('> apy initialization failed', err);
@@ -97,13 +102,40 @@ const updateApys = async () => {
   setTimeout(updateApys, REFRESH_INTERVAL);
 };
 
+const updateBoostAprs = async () => {
+  console.log('> updating boost aprs');
+  const start = Date.now();
+  try {
+    const updatedBoostAprs = await fetchBoostAprs();
+    boostAprs = {
+      ...boostAprs,
+      ...updatedBoostAprs,
+    };
+    //-1 will be returned when boost has ended and it will be removed from the api response
+    Object.keys(boostAprs)
+      .filter(boostId => boostAprs[boostId] === -1)
+      .forEach(boostId => {
+        delete boostAprs[boostId];
+      });
+    await saveBoostsToRedis();
+    console.log(`> updated boost aprs (${(Date.now() - start) / 1000}s)`);
+  } catch (err) {
+    console.error(`> error updating boost aprs: ${err.message}`);
+  }
+
+  setTimeout(updateBoostAprs, BOOST_REFRESH_INTERVAL);
+};
+
 const initApyService = async () => {
   let cachedApy = await getKey('APY');
   let cachedApyBreakdown = await getKey('APY_BREAKDOWN');
+  let cachedBoostAprs = await getKey('BOOST_APRS');
   apys = cachedApy ?? {};
   apyBreakdowns = cachedApyBreakdown ?? {};
+  boostAprs = cachedBoostAprs ?? {};
 
   setTimeout(updateApys, INIT_DELAY);
+  setTimeout(updateBoostAprs, 10 * 1000);
 };
 
 const saveToRedis = async () => {
@@ -111,4 +143,8 @@ const saveToRedis = async () => {
   await setKey('APY_BREAKDOWN', apyBreakdowns);
 };
 
-module.exports = { getApys, initApyService };
+const saveBoostsToRedis = async () => {
+  await setKey('BOOST_APRS', boostAprs);
+};
+
+module.exports = { getApys, getBoostAprs, initApyService };

--- a/src/api/stats/getBoostAprs.ts
+++ b/src/api/stats/getBoostAprs.ts
@@ -1,0 +1,153 @@
+import {
+  ContractCallContext,
+  ContractCallResults,
+  ContractCallReturnContext,
+  Multicall,
+} from 'ethereum-multicall';
+import { chunk } from 'lodash';
+import chainIdMap from '../../../packages/address-book/util/chainIdMap';
+import { web3Factory } from '../../utils/web3';
+import { getAllBoosts } from '../boosts/getBoosts';
+import { Boost } from '../boosts/types';
+import BoostAbi from '../../abis/BeefyBoost.json';
+import BigNumber from 'bignumber.js';
+import fetchPrice from '../../utils/fetchPrice';
+import { Vault } from '../vaults/types';
+const { getVaultByID } = require('../stats/getMultichainVaults');
+
+const MULTICALL_BATCH_SIZE = 768;
+
+const updateBoostAprsForChain = async (chain: string, boosts: Boost[]) => {
+  const web3 = web3Factory(chainIdMap[chain]);
+  const multicallAddress =
+    chainIdMap[chain] === 2222
+      ? '0xdAaD0085e5D301Cb5721466e600606AB5158862b'
+      : '0xcA11bde05977b3631167028862bE2a173976CA11';
+
+  const multicall = new Multicall({
+    web3Instance: web3,
+    tryAggregate: true,
+    multicallCustomContractAddress: multicallAddress,
+  });
+
+  const callContext: ContractCallContext[] = mapBoostsToCalls(boosts);
+  const promises: Promise<ContractCallResults>[] = chunk(callContext, MULTICALL_BATCH_SIZE).map(
+    batch => multicall.call(batch)
+  );
+
+  try {
+    const results = await Promise.allSettled(promises);
+
+    const fulfilledResults = results
+      .filter(promise => promise.status === 'fulfilled')
+      .flatMap((res: PromiseFulfilledResult<ContractCallResults>) =>
+        Object.entries(res.value.results)
+      );
+
+    const boostAprs: { [boostId: string]: number } = {};
+    for (const [id, callReturnContext] of fulfilledResults) {
+      const apr = await mapResponseToBoostApr(callReturnContext);
+      if (apr != null) boostAprs[id] = apr;
+    }
+    return boostAprs;
+  } catch (err) {
+    console.log(err.message);
+    return {};
+  }
+};
+
+const mapBoostsToCalls = (boosts: Boost[]): ContractCallContext[] => {
+  return boosts.map(boost => ({
+    reference: boost.id,
+    contractAddress: boost.earnContractAddress,
+    abi: BoostAbi,
+    calls: [
+      {
+        reference: 'totalSupply',
+        methodName: 'totalSupply',
+        methodParameters: [],
+      },
+      {
+        reference: 'rewardRate',
+        methodName: 'rewardRate',
+        methodParameters: [],
+      },
+      {
+        reference: 'periodFinish',
+        methodName: 'periodFinish',
+        methodParameters: [],
+      },
+    ],
+    context: boost,
+  }));
+};
+/**
+ * @param callReturnContext
+ * @returns -1 if boost has expired, null if error ocurred, apr number value if successful
+ */
+const mapResponseToBoostApr = async (
+  callReturnContext: ContractCallReturnContext
+): Promise<number> => {
+  const boost: Boost = callReturnContext.originalContractCallContext.context;
+  const totalSupply = new BigNumber(callReturnContext.callsReturnContext[0].returnValues[0].hex);
+  const rewardRate = new BigNumber(callReturnContext.callsReturnContext[1].returnValues[0].hex);
+  const periodFinish = new BigNumber(callReturnContext.callsReturnContext[2].returnValues[0].hex);
+
+  if (periodFinish.times(1000).lte(new BigNumber(Date.now()))) return -1;
+
+  try {
+    const vault: Vault = getVaultByID(boost.poolId);
+    const depositTokenPrice = await fetchPrice({ oracle: vault.oracle, id: vault.oracleId });
+    const earnedTokenPrice = await fetchPrice({
+      oracle: boost.earnedOracle,
+      id: boost.earnedOracleId,
+    });
+
+    //Price is missing, we can't consider this as a succesful calculation
+    if (depositTokenPrice === 0) {
+      return null;
+    }
+
+    const amountStakedInUsd = totalSupply
+      .times(vault.pricePerFullShare)
+      .times(depositTokenPrice)
+      .shiftedBy(-(vault.tokenDecimals + 18));
+    const yearlyRewardsInUsd = rewardRate
+      .times(earnedTokenPrice)
+      .times(365 * 24 * 3600)
+      .shiftedBy(-boost.earnedTokenDecimals);
+
+    return yearlyRewardsInUsd.dividedBy(amountStakedInUsd).toNumber();
+  } catch (err) {
+    console.log(`[boost aprs] error calculating apr for ${boost.id}: ${err.message}`);
+    return null;
+  }
+};
+
+export const fetchBoostAprs = async () => {
+  const boostByChain: { [chain: string]: Boost[] } = getAllBoosts().reduce(
+    (allBoosts, previousBoost) => {
+      if (!allBoosts[previousBoost.chain]) allBoosts[previousBoost.chain] = [];
+      allBoosts[previousBoost.chain].push(previousBoost);
+      return allBoosts;
+    },
+    {}
+  );
+
+  const chainPromises = Object.keys(boostByChain).map(chain =>
+    updateBoostAprsForChain(chain, boostByChain[chain])
+  );
+
+  try {
+    let results = await Promise.all(chainPromises);
+    return results.reduce(
+      (allBoostAprs, currentChainBoostChainAprs) => ({
+        ...allBoostAprs,
+        ...currentChainBoostChainAprs,
+      }),
+      {}
+    );
+  } catch (error) {
+    return {};
+  }
+};

--- a/src/api/stats/getMultichainVaults.js
+++ b/src/api/stats/getMultichainVaults.js
@@ -15,6 +15,7 @@ let vaultsByChain = {};
 let multichainVaults = [];
 var multichainVaultsCounter = 0;
 var multichainActiveVaultsCounter = 0;
+var vaultsByID = {};
 
 const getMultichainVaults = () => {
   return multichainVaults;
@@ -22,6 +23,10 @@ const getMultichainVaults = () => {
 
 const getSingleChainVaults = chain => {
   return vaultsByChain[chain];
+};
+
+const getVaultByID = vaultId => {
+  return vaultsByID[vaultId];
 };
 
 const updateMultichainVaults = async () => {
@@ -43,6 +48,11 @@ const updateMultichainVaults = async () => {
     multichainActiveVaultsCounter = multichainVaults.filter(
       vault => vault.status === 'active'
     ).length;
+
+    vaultsByID = multichainVaults.reduce((allVaults, currentVault) => {
+      allVaults[currentVault.id] = currentVault;
+      return allVaults;
+    }, {});
 
     console.log(
       '> updated',
@@ -96,6 +106,10 @@ export const initVaultService = async () => {
   multichainActiveVaultsCounter = multichainVaults.filter(
     vault => vault.status === 'active'
   ).length;
+  vaultsByID = multichainVaults.reduce((allVaults, currentVault) => {
+    allVaults[currentVault.id] = currentVault;
+    return allVaults;
+  }, {});
 
   setTimeout(updateMultichainVaults, INIT_DELAY);
 };
@@ -104,4 +118,4 @@ const saveToRedis = async () => {
   await setKey('VAULTS_BY_CHAIN', vaultsByChain);
 };
 
-module.exports = { getMultichainVaults, getSingleChainVaults, initVaultService };
+module.exports = { getMultichainVaults, getSingleChainVaults, getVaultByID, initVaultService };

--- a/src/api/stats/index.js
+++ b/src/api/stats/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getApys } = require('./getApys');
+const { getApys, getBoostAprs } = require('./getApys');
 
 const TIMEOUT = 5 * 60 * 1000;
 
@@ -38,4 +38,16 @@ async function apyBreakdowns(ctx) {
   }
 }
 
-module.exports = { apy, apyBreakdowns };
+async function boostApr(ctx) {
+  try {
+    ctx.request.socket.setTimeout(TIMEOUT);
+    let boostAprs = getBoostAprs();
+
+    ctx.status = 200;
+    ctx.body = boostAprs;
+  } catch (err) {
+    ctx.throw(500, err);
+  }
+}
+
+module.exports = { apy, apyBreakdowns, boostApr };

--- a/src/api/vaults/types.ts
+++ b/src/api/vaults/types.ts
@@ -1,0 +1,27 @@
+import BigNumber from 'bignumber.js';
+
+export type Vault = {
+  id: string;
+  name: string;
+  token: string;
+  tokenAddress: string;
+  tokenDecimals: number;
+  tokenProviderId: string;
+  earnedToken: string;
+  earnedTokenAddress: string;
+  earnContractAddress: string;
+  oracle: 'lps' | 'tokens';
+  oracleId: 'tokens';
+  status: 'active' | 'paused' | 'eol';
+  platformId: string;
+  assets: string[];
+  strategyTypeId: string;
+  risks: string[];
+  addLiquidityUrl?: string;
+  removeLiquidityUrl?: string;
+  network: string;
+  strategy: string;
+  lastHarvest?: number;
+  pricePerFullShare: BigNumber;
+  createdAt: number;
+};

--- a/src/router.js
+++ b/src/router.js
@@ -20,6 +20,8 @@ const { getTreasury } = require('./api/treasury');
 
 router.get('/apy', stats.apy);
 router.get('/apy/breakdown', stats.apyBreakdowns);
+router.get('/apy/boosts', stats.boostApr);
+
 router.get('/bifibuyback', bifibuyback);
 
 router.get('/tvl', tvl.vaultTvl);


### PR DESCRIPTION
- Added Boost APR endpoint at `/apy/boosts`
- Boost APR data is updated every 2 minutes
- Only APR of **active** boosts are shown, a value of 0 can be set for expired boosts if we wanted to, just let me know.
- Added vault mapping by ID so as to efficiently search for specific vaults (needed in order to fetch deposit token data for boosts)
- Improved vault/boost typing