### PR TITLE
Stop wrong GMX token price propagation

### DIFF
--- a/src/data/avax/joeDualLpPools.json
+++ b/src/data/avax/joeDualLpPools.json
@@ -596,13 +596,13 @@
     "oracleB": "tokens",
     "oracleIdB": "GMX",
     "decimalsB": "1e18",
-    "lp0": {
+    "lp1": {
       "address": "0x62edc0692BD897D2295872a9FFCac5425011c661",
       "oracle": "tokens",
       "oracleId": "GMX",
       "decimals": "1e18"
     },
-    "lp1": {
+    "lp0": {
       "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
       "oracle": "tokens",
       "oracleId": "AVAX",


### PR DESCRIPTION
GMX price is wrongly being set in arbitrum since the liquidity pool is almost empty. By swapping lp0 and lp1 in the avax GMX lp we take GMX as unknown and its price is calculated correctly. This stops AVAX's, DAI.e's and others's price from being wrongly set