### PR TITLE
Active snapshot proposals

### DIFF
--- a/src/api/snapshot/getProposals.ts
+++ b/src/api/snapshot/getProposals.ts
@@ -1,14 +1,5 @@
 import { getKey, setKey } from '../../utils/redisHelper';
-import {
-  Cached,
-  CachedNoOpenProposal,
-  CachedProposal,
-  CachedSpace,
-  isCachedNoOpenProposal,
-  isCachedProposal,
-  isCachedSpace,
-  Proposal,
-} from './types';
+import { Cached, CachedProposals, CachedSpace, isCachedSpace, Proposal, Proposals } from './types';
 import { getSnapshotApi } from './getSnapshotApi';
 import { isBefore, sub } from 'date-fns';
 
@@ -20,21 +11,21 @@ const MAX_PROPOSAL_AGE_MINS = 15; // minutes
 const ALLOW_FROM_ADMINS: boolean = true;
 const ALLOW_FROM_MEMBERS: boolean = true;
 const ALLOW_FROM_LIST: boolean = true;
-const ALLOW_FROM_ANYONE: boolean = false;
+const ALLOW_FROM_ANYONE: boolean = true;
 
 const ALLOW_LIST: string[] = ['0x280A53cBf252F1B5F6Bde7471299c94Ec566a7C8'];
 
 let cachedSpace: CachedSpace | null = null;
-let cachedProposal: CachedProposal | CachedNoOpenProposal | null = null;
+let cachedProposals: CachedProposals | null = null;
 
 async function getCachedSpace(): Promise<CachedSpace | null> {
   const value = await getKey(CACHE_KEY_SPACE);
   return isCachedSpace(value) ? value : null;
 }
 
-async function getCachedProposal(): Promise<CachedProposal | CachedNoOpenProposal | null> {
+async function getCachedProposals(): Promise<CachedProposals | null> {
   const value = await getKey(CACHE_KEY_PROPOSAL);
-  return isCachedProposal(value) || isCachedNoOpenProposal(value) ? value : null;
+  return value && value.proposals ? value : null;
 }
 
 function timestamp<T extends {}>(obj: T): Cached<T> {
@@ -49,15 +40,13 @@ function isStale<T extends Cached<{}>>(obj: T, maxMinutes: number): boolean {
   return isBefore(obj.updatedAt, maxAge);
 }
 
-function hasProposalEnded(proposal: CachedProposal): boolean {
+function hasProposalEnded(proposal: Proposal): boolean {
   return isBefore(proposal.end * 1000, new Date());
 }
 
 async function updateSpace() {
   const api = await getSnapshotApi();
   const space = await api.getSpace(SPACE_ID);
-
-  // console.debug('[snapshot]', 'updated space:', space);
 
   cachedSpace = timestamp(space);
 
@@ -82,50 +71,32 @@ function getValidAuthors() {
   return authors.map(address => address.toLowerCase());
 }
 
-async function setProposal(proposal: Proposal) {
-  // console.debug('[snapshot]', 'updated proposal:', proposal);
+async function setProposals(proposals: Proposals) {
+  cachedProposals = timestamp(proposals);
 
-  cachedProposal = timestamp(proposal);
-
-  await setKey(CACHE_KEY_PROPOSAL, cachedProposal);
+  await setKey(CACHE_KEY_PROPOSAL, cachedProposals);
 }
 
-async function setNoProposal() {
-  console.debug('updated proposal: no valid proposals active');
-
-  cachedProposal = timestamp({
-    id: 'no-open-proposal',
-  });
-
-  await setKey(CACHE_KEY_PROPOSAL, cachedProposal);
-}
-
-async function updateProposal() {
+async function updateProposals() {
   if (!cachedSpace) {
     console.error('Can not update proposal without updating space first.');
     return;
   }
 
   const api = await getSnapshotApi();
-  const proposals = await api.getProposals(SPACE_ID, 'open', ALLOW_FROM_ANYONE ? 1 : 10, 0);
+  const proposalResponse = await api.getProposals(SPACE_ID, 'open', 10, 0);
 
-  // console.debug('[snapshot]', proposals);
+  const authors = getValidAuthors();
+  const proposals: Proposal[] = proposalResponse
+    .map(p => {
+      return {
+        ...p,
+        coreProposal: authors.includes(p.author.toLowerCase()),
+      };
+    })
+    .filter(p => (ALLOW_FROM_ANYONE ? true : p.coreProposal));
 
-  if (proposals.length) {
-    if (ALLOW_FROM_ANYONE) {
-      await setProposal(proposals[0]);
-    } else {
-      const authors = getValidAuthors();
-      const proposal = proposals.find(p => authors.includes(p.author.toLowerCase()));
-      if (proposal) {
-        await setProposal(proposal);
-      } else {
-        await setNoProposal();
-      }
-    }
-  } else {
-    await setNoProposal();
-  }
+  await setProposals({ proposals });
 }
 
 async function updateSpaceIfNeeded() {
@@ -134,19 +105,19 @@ async function updateSpaceIfNeeded() {
   }
 }
 
-async function updateProposalIfNeeded() {
-  if (!cachedProposal || isStale(cachedProposal, MAX_PROPOSAL_AGE_MINS)) {
-    await updateProposal();
+async function updateProposalsIfNeeded() {
+  if (!cachedProposals || isStale(cachedProposals, MAX_PROPOSAL_AGE_MINS)) {
+    await updateProposals();
   }
 }
 
 async function updateIfNeeded() {
   await updateSpaceIfNeeded();
-  await updateProposalIfNeeded();
+  await updateProposalsIfNeeded();
 }
 
 export async function initProposalsService() {
-  [cachedSpace, cachedProposal] = await Promise.all([getCachedSpace(), getCachedProposal()]);
+  [cachedSpace, cachedProposals] = await Promise.all([getCachedSpace(), getCachedProposals()]);
 
   await updateIfNeeded();
 
@@ -155,9 +126,17 @@ export async function initProposalsService() {
   }, MAX_PROPOSAL_AGE_MINS * 60 * 1000 + 1000);
 }
 
-export function getLatestProposal(): CachedProposal | null {
-  if (isCachedProposal(cachedProposal) && !hasProposalEnded(cachedProposal)) {
-    return cachedProposal;
+export function getLatestProposal(): Proposal | null {
+  if (cachedProposals && cachedProposals.proposals.length > 0) {
+    return cachedProposals.proposals[0];
+  }
+
+  return null;
+}
+
+export function getActiveProposals(): Proposal[] | null {
+  if (cachedProposals) {
+    return cachedProposals.proposals.filter(p => !hasProposalEnded(p));
   }
 
   return null;

--- a/src/api/snapshot/getSnapshotApi.ts
+++ b/src/api/snapshot/getSnapshotApi.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, gql, NormalizedCacheObject } from '@apollo/client/core';
 import { client } from '../../apollo/client';
-import { Proposal, Space } from './types';
+import { Proposal, ProposalApiResponse, Space } from './types';
 
 // https://docs.snapshot.org/graphql-api#space
 const QUERY_SPACE = gql`
@@ -25,6 +25,7 @@ const QUERY_PROPOSALS = gql`
     ) {
       id
       title
+      start
       end
       author
     }
@@ -54,8 +55,8 @@ class SnapshotApi {
     state: 'open' | 'closed' = 'open',
     first: number = 10,
     skip: number = 0
-  ): Promise<Proposal[]> {
-    const result = await this.client.query<{ proposals: Proposal[] }>({
+  ): Promise<ProposalApiResponse[]> {
+    const result = await this.client.query<{ proposals: ProposalApiResponse[] }>({
       query: QUERY_PROPOSALS,
       variables: {
         spaceId,

--- a/src/api/snapshot/index.ts
+++ b/src/api/snapshot/index.ts
@@ -1,4 +1,4 @@
-import { getLatestProposal } from './getLatestProposal';
+import { getLatestProposal, getActiveProposals } from './getProposals';
 import Koa from 'koa';
 
 // latest proposal to display on app
@@ -13,4 +13,15 @@ function latest(ctx: Koa.Context) {
   }
 }
 
-export { latest };
+function active(ctx: Koa.Context) {
+  try {
+    const activeProposals = getActiveProposals();
+    ctx.status = 200;
+    ctx.body = activeProposals;
+  } catch (err) {
+    console.error(err);
+    ctx.status = 500;
+  }
+}
+
+export { latest, active };

--- a/src/api/snapshot/types.ts
+++ b/src/api/snapshot/types.ts
@@ -4,15 +4,24 @@ export type Space = {
   admins: string;
 };
 
-export type Proposal = {
+export type ProposalApiResponse = {
   id: string;
   title: string;
+  start: number;
   end: number;
   author: string;
 };
 
+export type Proposal = ProposalApiResponse & {
+  coreProposal: boolean;
+};
+
 export type NoOpenProposal = {
   id: 'no-open-proposal';
+};
+
+export type Proposals = {
+  proposals: Proposal[];
 };
 
 export type Cached<T extends {}> = T & {
@@ -20,8 +29,7 @@ export type Cached<T extends {}> = T & {
 };
 
 export type CachedSpace = Cached<Space>;
-export type CachedProposal = Cached<Proposal>;
-export type CachedNoOpenProposal = Cached<NoOpenProposal>;
+export type CachedProposals = Cached<Proposals>;
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return value && typeof value === 'object';
@@ -29,18 +37,4 @@ function isObject(value: unknown): value is Record<string, unknown> {
 
 export function isCachedSpace(space: unknown): space is CachedSpace {
   return isObject(space) && !!space.id && !!space.members && !!space.admins && !!space.updatedAt;
-}
-
-export function isCachedProposal(proposal: unknown): proposal is CachedProposal {
-  return (
-    isObject(proposal) &&
-    !!proposal.id &&
-    !!proposal.title &&
-    !!proposal.end &&
-    !!proposal.updatedAt
-  );
-}
-
-export function isCachedNoOpenProposal(obj: unknown): obj is CachedNoOpenProposal {
-  return isObject(obj) && obj.id === 'no-open-proposal' && !!obj.updatedAt;
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,7 @@ import { initTokenService } from './api/tokens/getTokens';
 import { initConfigService } from './api/config/getConfig';
 import { initVaultFeeService } from './api/vaults/getVaultFees';
 import { initTreasuryService } from './api/treasury/getTreasury';
-import { initProposalsService } from './api/snapshot/getLatestProposal';
+import { initProposalsService } from './api/snapshot/getProposals';
 
 require('./utils/redisHelper').initRedis();
 

--- a/src/router.js
+++ b/src/router.js
@@ -56,6 +56,7 @@ router.get('/config/:chainId', getChainConfig);
 router.get('/treasury', getTreasury);
 
 router.get('/snapshot/latest', snapshot.latest);
+router.get('/snapshot/active', snapshot.active);
 
 router.get('/', noop);
 


### PR DESCRIPTION
- Cache all active snapshot proposals
- /active endpoint to retrieve them all
- Flag snapshots created by core members as such

Example:

```
  {
    "id": "0xa206d84a9ff4a8cd3ecdf56a2b0892ff89cf38c66fe57730a7736095b401c8b4",
    "title": "[BSP:02] Profit Mandate",
    "start": 1675572087,
    "end": 1676851200,
    "author": "0x280A53cBf252F1B5F6Bde7471299c94Ec566a7C8",
    "coreProposal": true
  }