### PR TITLE
Added missing bifiMaxiStrategies and fixed wrong ones

### DIFF
--- a/packages/address-book/address-book/aurora/platforms/beefyfinance.ts
+++ b/packages/address-book/address-book/aurora/platforms/beefyfinance.ts
@@ -13,7 +13,7 @@ export const beefyfinance = {
   treasury: '0x8c2d54BA94f4638f1bb91f623F378B66d6023324',
   beefyFeeRecipient: '0x9dA9f3C6c45F1160b53D395b0A982aEEE1D212fE',
   multicall: '0x1198f78efd67DFc917510aaA07d49545f4B24f11',
-  bifiMaxiStrategy: '0xD25c56DAbcda719F1c67fE8fc0760f8B942aC95C',
+  bifiMaxiStrategy: '0x22b3d90BDdC3Ad5F2948bE3914255C64Ebc8c9b3',
   voter: '0x5e1caC103F943Cd84A1E92dAde4145664ebf692A',
   beefyFeeConfig: '0xD5431d39858A86c78d72541a58acFC37b793b91d',
 } as const;

--- a/packages/address-book/address-book/canto/platforms/beefyfinance.ts
+++ b/packages/address-book/address-book/canto/platforms/beefyfinance.ts
@@ -13,7 +13,7 @@ export const beefyfinance = {
   treasury: treasuryMultisig,
   beefyFeeRecipient: '0xeD7b88EDd899d578581DCcfce80F43D1F395b93f',
   multicall: '0xc34b9c9DBB39Be0Ef850170127A7b4283484f804',
-  //bifiMaxiStrategy: '0x6207536011918F1A0D8a53Bc426f4Fd54df2E5a8',
+  bifiMaxiStrategy: '0x3B9bcE784d0582f08ED8a8aDA6593f53D1efaFD0',
   voter: '0x5e1caC103F943Cd84A1E92dAde4145664ebf692A',
   beefyFeeConfig: '0x09EF0e7b555599A9F810789FfF68Db8DBF4c51a0',
   vaultFactory: '0x4B5BB994cB7Bd88F064A1f4141a2399000339aCc',

--- a/packages/address-book/address-book/ethereum/platforms/beefyfinance.ts
+++ b/packages/address-book/address-book/ethereum/platforms/beefyfinance.ts
@@ -13,7 +13,7 @@ export const beefyfinance = {
   treasury: treasuryMultisig,
   beefyFeeRecipient: '0x8237f3992526036787E8178Def36291Ab94638CD',
   multicall: '0x9dA9f3C6c45F1160b53D395b0A982aEEE1D212fE',
-  // bifiMaxiStrategy: '0xd1bAb603eee03fA99A378d90d5d83186fEB81aA9',
+  bifiMaxiStrategy: '0x697aFD2D17e7e274529ABd2db49A2953bb081091',
   voter: '0x5e1caC103F943Cd84A1E92dAde4145664ebf692A',
   beefyFeeConfig: '0x3d38BA27974410679afF73abD096D7Ba58870EAd',
   vaultFactory: '0xC551dDCE8e5E657503Cd67A39713c06F2c0d2e97',

--- a/packages/address-book/address-book/fuse/platforms/beefyfinance.ts
+++ b/packages/address-book/address-book/fuse/platforms/beefyfinance.ts
@@ -13,7 +13,7 @@ export const beefyfinance = {
   treasury: '0x922f8807E781739DDefEe51df990457B522cBCf5',
   beefyFeeRecipient: '0x32C82EE8Fca98ce5114D2060c5715AEc714152FB',
   multicall: '0xFE40f6eAD11099D91D51a945c145CFaD1DD15Bb8',
-  bifiMaxiStrategy: '0x79149B500f0d796aA7f85e0170d16C7e79BAd3C5',
+  bifiMaxiStrategy: '0x24AAaB9DA14308bAf9d670e2a37369FE8Cb5Fe36',
   validator: '0xEc4B821541f62b63832ceE400d6c29bCc84E4e38',
   voter: '0x5e1caC103F943Cd84A1E92dAde4145664ebf692A',
 } as const;

--- a/packages/address-book/address-book/kava/platforms/beefyfinance.ts
+++ b/packages/address-book/address-book/kava/platforms/beefyfinance.ts
@@ -15,7 +15,7 @@ export const beefyfinance = {
   treasury: treasuryMultisig,
   beefyFeeRecipient: '0xF0d26842c3935A618e6980C53fDa3A2D10A02eb7',
   multicall: '0x13C6bCC2411861A31dcDC2f990ddbe2325482222',
-  // bifiMaxiStrategy: '0xd1bAb603eee03fA99A378d90d5d83186fEB81aA9',
+  bifiMaxiStrategy: '0xaC3778DC45B5e415DaA78CCC31f25169bD98C43A',
   voter: '0x5e1caC103F943Cd84A1E92dAde4145664ebf692A',
   beefyFeeConfig: '0xa9E6E271b27b20F65394914f8784B3B860dBd259',
   vaultFactory: '0xCD9b038F012Ecd6b2739934426dDe3D4577e1d3C',

--- a/packages/address-book/address-book/metis/platforms/beefyfinance.ts
+++ b/packages/address-book/address-book/metis/platforms/beefyfinance.ts
@@ -13,7 +13,7 @@ export const beefyfinance = {
   treasury: treasuryMultisig,
   beefyFeeRecipient: '0x2cC364255206A7e14bF59ADB1fc5770DbA48CB3f',
   multicall: '0x13C6bCC2411861A31dcDC2f990ddbe2325482222',
-  bifiMaxiStrategy: '0xEA01ca0423acb8476E1D3Bae572021c2aA9bd410',
+  bifiMaxiStrategy: '0x436D5127F16fAC1F021733dda090b5E6DE30b3bB',
   voter: '0x5e1caC103F943Cd84A1E92dAde4145664ebf692A',
   beefyFeeConfig: '0x11cB33Ef34C53DfcaA3aDdDE9a83f742ffFcfa27',
   vaultFactory: '0x52d998A110E447648095671bb66993461Da9ea38',

--- a/packages/address-book/address-book/optimism/platforms/beefyfinance.ts
+++ b/packages/address-book/address-book/optimism/platforms/beefyfinance.ts
@@ -13,7 +13,7 @@ export const beefyfinance = {
   treasury: treasuryMultisig,
   beefyFeeRecipient: '0x3Cd5Ae887Ddf78c58c9C1a063EB343F942DbbcE8',
   multicall: '0x820ae7BF39792D7ce7befC70B0172F4D267F1938',
-  bifiMaxiStrategy: '0xD98a4923e8B8f298028bFB1874c920059605A89a',
+  bifiMaxiStrategy: '0xC808b28A006c91523De75EA23F48BE8b7a9536D1',
   voter: '0x5e1caC103F943Cd84A1E92dAde4145664ebf692A',
   beefyFeeConfig: '0x216EEE15D1e3fAAD34181f66dd0B665f556a638d',
   vaultFactory: '0xA6D3769faC465FC0415e7E9F16dcdC96B83C240B',


### PR DESCRIPTION
I use beefy api for my personal project and found some inconsistencies in vault configs. `bifiMaxiStrategy` sometimes pointed to `BifiMaxi vault` sometimes to `BifiMaxi strategy`, made them all point to strategy. Also added missing ones.