### PR TITLE
Switch jBRL to Jarvis price feed

### DIFF
--- a/src/abis/IJarvisPriceFeed.json
+++ b/src/abis/IJarvisPriceFeed.json
@@ -1,0 +1,517 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract ISynthereumFinder",
+        "name": "_synthereumFinder",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "admin",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "maintainer",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct SynthereumChainlinkPriceFeed.Roles",
+        "name": "_roles",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "priceIdentifier",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RemovePair",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "priceIdentifier",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum ISynthereumChainlinkPriceFeed.Type",
+        "name": "kind",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "aggregator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "intermediatePairs",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "SetPair",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAINTAINER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_priceIdentifier",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getAggregator",
+    "outputs": [
+      {
+        "internalType": "contract AggregatorV3Interface",
+        "name": "aggregator",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_priceIdentifier",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getLatestPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_priceIdentifiers",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "getLatestPrices",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "prices",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRoleMember",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_priceIdentifier",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint80",
+        "name": "_roundId",
+        "type": "uint80"
+      }
+    ],
+    "name": "getRoundPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_priceIdentifier",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isPriceSupported",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isSupported",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "pairs",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isSupported",
+        "type": "bool"
+      },
+      {
+        "internalType": "enum ISynthereumChainlinkPriceFeed.Type",
+        "name": "priceType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "contract AggregatorV3Interface",
+        "name": "aggregator",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_priceIdentifier",
+        "type": "bytes32"
+      }
+    ],
+    "name": "removePair",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum ISynthereumChainlinkPriceFeed.Type",
+        "name": "_kind",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_priceIdentifier",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_aggregator",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_intermediatePairs",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "setPair",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "synthereumFinder",
+    "outputs": [
+      {
+        "internalType": "contract ISynthereumFinder",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -693,7 +693,7 @@ async function performUpdateAmmPrices() {
 
   const linearPoolPrice = ammPrices.then(
     async ({ tokenPrices }): Promise<Record<string, number>> => {
-      const jbrlTokenPrice = await fetchJbrlPrice(tokenPrices);
+      const jbrlTokenPrice = await fetchJbrlPrice();
       const yVaultPrices = await fetchyVaultPrices(tokenPrices);
       const vaultPrices = await fetchVaultPrices(tokenPrices);
       const wrappedAavePrices = await fetchWrappedAavePrices(tokenPrices);

--- a/src/utils/fetchJbrlPrice.js
+++ b/src/utils/fetchJbrlPrice.js
@@ -1,43 +1,19 @@
 import BigNumber from 'bignumber.js';
 import { web3Factory } from './web3';
-import IBalancerVault from '../abis/IBalancerVault.json';
-
+import IPriceFeed from '../abis/IJarvisPriceFeed.json';
 import { POLYGON_CHAIN_ID } from '../constants';
 import { getContractWithProvider } from './contractHelper';
 
-const brz = '0x491a4eB4f1FC3BfF8E1d2FC856a6A46663aD556f';
-const jbrl = '0xf2f77FE7b8e66571E0fca7104c4d670BF1C8d722';
-const poolId = '0xe22483774bd8611be2ad2f4194078dac9159f4ba0000000000000000000008f0';
-const vault = '0xBA12222222228d8Ba445958a75a0704d566BF2C8';
-const one = new BigNumber('1e18');
+const priceFeed = '0x12F513D977B47D1d155bC5ED4d295c1B10D6D027';
+const priceId = '0x42524c5553440000000000000000000000000000000000000000000000000000';
 
-const fetchJbrlPrice = async tokenPrices => {
-  const price = await getJbrlPrice(tokenPrices, POLYGON_CHAIN_ID);
-  return { jBRL: price };
-};
+const fetchJbrlPrice = async () => {
+  const web3 = web3Factory(POLYGON_CHAIN_ID);
 
-const getJbrlPrice = async (tokenPrices, chainId) => {
-  const web3 = web3Factory(chainId);
-  const vaultContract = getContractWithProvider(IBalancerVault, vault, web3);
+  const priceFeedContract = getContractWithProvider(IPriceFeed, priceFeed, web3);
+  const price = new BigNumber(await priceFeedContract.methods.getLatestPrice(priceId).call()).dividedBy('1e18'),
 
-  const data = await vaultContract.methods.getPoolTokens(poolId).call();
-  let reserveA = new BigNumber(0);
-  let reserveB = new BigNumber(0);
-  for (let i = 0; i < data.tokens.length; i++) {
-    if (data.tokens[i] == jbrl) {
-      reserveA = new BigNumber(data.balances[i]);
-    } else if (data.tokens[i] == brz) {
-      reserveB = new BigNumber(data.balances[i]);
-    }
-  }
-
-  let price = one
-    .times(reserveB)
-    .dividedBy(reserveA.plus(one))
-    .times(tokenPrices['BRZ'])
-    .dividedBy('1e4');
-
-  return price.toNumber();
+  return {jBRL: price.toNumber()};
 };
 
 export { fetchJbrlPrice };


### PR DESCRIPTION
jBRL is over priced by 50% due to linear math being used on a stable balancer vault. New method uses the price that Jarvis mints and redeems jBRL at using USDC.