### PR TITLE
Untested: Update workflow actions

### DIFF
--- a/.github/workflows/heroku-deploy.yaml
+++ b/.github/workflows/heroku-deploy.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
+      - uses: akhileshns/heroku-deploy@v3.12.13 # This is the action
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: "beefy-api" #Must be unique in Heroku

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -20,10 +20,10 @@ jobs:
       # get repo code
       - uses: actions/checkout@v2
       # install node
-      - name: Use Node.js 15.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
         with:
-          node-version: '15.x'
+          node-version: '16.x'
       # install packages
       - run: yarn --frozen-lockfile
       # run checksum test

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -23,11 +23,10 @@ jobs:
       # get repo code
       - uses: actions/checkout@v2
       # install node
-      - name: Use Node.js 15.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
         with:
-          node-version: '15.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '16.x'
       # install packages
       - run: yarn --frozen-lockfile
       # run checksum test
@@ -36,7 +35,7 @@ jobs:
       - run: yarn compile
       # bump package version and commit. Note that this won't create an infinite github action push loop, as we have added package.json to paths-ignore.
       - name: 'Automated Version Bump'
-        uses: 'phips28/gh-action-bump-version@v8.0.18'
+        uses: 'phips28/gh-action-bump-version@v9.1.0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGEJSON_DIR: 'packages/address-book'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "repository": "beefyfinance/beefy-api",
   "license": "MIT",
+  "engines": {
+    "node": "16.x"
+  },
   "scripts": {
     "install-all": "yarn && cd packages/address-book && yarn",
     "start": "ts-node --transpile-only src/app.ts",


### PR DESCRIPTION
Update GH workflow actions to use:
- node version 16
- latest version of `akhileshns/heroku-deploy` (3.12.12 -> 3.12.13)
- latest version of `phips28/gh-action-bump-version` (8.0.18 -> 9.1.0)

Old version of `phips28/gh-action-bump-version` was causing actions to fail due to using a docker container with a really old version of debian