### PR TITLE
Add Chronos LPs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "arb:swapfish:add": "ts-node scripts/add-farm.ts --network arbitrum --project swapfishArb --newFee true",
     "arb:arbidex:add": "ts-node scripts/add-farm.ts --network arbitrum --project arbidex --newFee true",
     "arb:ramses:add": "ts-node scripts/add-solidly.ts --network arbitrum --project ramses --newFee true --lp",
+    "arb:chronos:add": "ts-node scripts/add-solidly.ts --network arbitrum --project chronos --newFee true --lp",
     "celo:sushi:add": "ts-node scripts/add-sushi.ts --network celo --project sushiCelo",
     "avax:pangolin:add": "ts-node scripts/add-sushi.ts --network avax --project pangolin",
     "avax:boostedjoe:add": "ts-node scripts/add-farm.ts --network avax --project boostedjoe",

--- a/packages/address-book/address-book/arbitrum/index.ts
+++ b/packages/address-book/address-book/arbitrum/index.ts
@@ -5,6 +5,7 @@ import { balancer } from './platforms/balancer';
 import { solidlizard } from './platforms/solidlizard';
 import { ramses } from './platforms/ramses';
 import { arbidex } from './platforms/arbidex';
+import { chronos } from './platforms/chronos';
 import { tokens } from './tokens/tokens';
 import { convertSymbolTokenMapToAddressTokenMap } from '../../util/convertSymbolTokenMapToAddressTokenMap';
 import Chain from '../../types/chain';
@@ -19,6 +20,7 @@ const _arbitrum = {
     solidlizard,
     ramses,
     arbidex,
+    chronos,
   },
   tokens,
   tokenAddressMap: convertSymbolTokenMapToAddressTokenMap(tokens),

--- a/packages/address-book/address-book/arbitrum/platforms/chronos.ts
+++ b/packages/address-book/address-book/arbitrum/platforms/chronos.ts
@@ -1,0 +1,5 @@
+export const chronos = {
+  router: '0xE708aA9E887980750C040a6A2Cb901c37Aa34f3b',
+  voter: '0xC72b5C6D2C33063E89a50B2F77C99193aE6cEe6c',
+  bifiEthLp: '0x04c106eddDBe89f2Ed983f52020F33D126fA544b',
+} as const;

--- a/scripts/add-solidly.ts
+++ b/scripts/add-solidly.ts
@@ -43,7 +43,7 @@ const {
     platforms: { solisnek },
   },
   arbitrum: {
-    platforms: { ramses },
+    platforms: { ramses, chronos },
   },
 } = addressBook;
 
@@ -130,6 +130,12 @@ const projects = {
     volatileFile: '../src/data/arbitrum/ramsesLpPools.json',
     voter: ramses.voter,
   },
+  chronos: {
+    prefix: 'chronos',
+    stableFile: '../src/data/arbitrum/chronosStableLpPools.json',
+    volatileFile: '../src/data/arbitrum/chronosLpPools.json',
+    voter: chronos.voter,
+  },
 };
 
 const args = yargs.options({
@@ -151,7 +157,7 @@ const args = yargs.options({
     describe: 'provide the solidly LP for gauge',
   },
   newFee: {
-    type: 'bool',
+    type: 'boolean',
     demandOption: true,
     describe: 'If the beefy fee is 9.5% use true else use false',
   },

--- a/src/api/stats/arbitrum/getChronosApys.js
+++ b/src/api/stats/arbitrum/getChronosApys.js
@@ -3,10 +3,9 @@ import { getRewardPoolApys } from '../common/getRewardPoolApys';
 const { arbitrumWeb3: web3 } = require('../../../utils/web3');
 const { ARBITRUM_CHAIN_ID: chainId } = require('../../../constants');
 const volatilePools = require('../../../data/arbitrum/chronosLpPools.json');
-// const stablePools = require('../../../data/arbitrum/chronosStableLpPools.json');
+const stablePools = require('../../../data/arbitrum/chronosStableLpPools.json');
 
-// const pools = [...volatilePools, ...stablePools];
-const pools = [...volatilePools];
+const pools = [...volatilePools, ...stablePools];
 export const getChronosApys = async () => {
   return getRewardPoolApys({
     web3: web3,

--- a/src/api/stats/arbitrum/getChronosStablePrices.js
+++ b/src/api/stats/arbitrum/getChronosStablePrices.js
@@ -1,0 +1,9 @@
+const getSolidlyStablePrices = require('../common/getSolidlyStablePrices');
+const { arbitrumWeb3: web3 } = require('../../../utils/web3');
+const pools = require('../../../data/arbitrum/chronosStableLpPools.json');
+
+const getChronosStablePrices = async tokenPrices => {
+  return await getSolidlyStablePrices(web3, pools, tokenPrices);
+};
+
+module.exports = getChronosStablePrices;

--- a/src/api/stats/getNonAmmPrices.ts
+++ b/src/api/stats/getNonAmmPrices.ts
@@ -69,6 +69,7 @@ import getCurveCeloPrices from './celo/getCurvePrices';
 import { getPolygonSolidlyStablePrices } from './matic/getPolygonSolidlyStablePrices';
 import getUniswapArbitrumPrices from './arbitrum/getUniswapPositionPrices';
 import getQuickGammaPrices from './matic/getQuickGammaPrices';
+import getChronosStablePrices from './arbitrum/getChronosStablePrices';
 
 export type NonAmmPrices = {
   prices: Record<string, number>;
@@ -159,6 +160,7 @@ export async function getNonAmmPrices(tokenPrices: Record<string, number>): Prom
     getStellaswapPrices(tokenPrices),
     getThenaGammaPrices(tokenPrices),
     getQuickGammaPrices(tokenPrices),
+    getChronosStablePrices(tokenPrices),
   ];
 
   // Setup error logs

--- a/src/data/arbitrum/chronosLpPools.json
+++ b/src/data/arbitrum/chronosLpPools.json
@@ -1,10 +1,171 @@
 [
   {
-    "name": "chronos-weth-bifi",
-    "address": "0x04c106eddDBe89f2Ed983f52020F33D126fA544b",
-    "gauge": "0xbd0cf21c20b5eb38b30e00f32893a80b5d823806",
+    "name": "chronos-ageur-usdc.e",
+    "address": "0x0DEf5c34285b67d9f7467129FD522D0818b45E31",
+    "gauge": "0x911f73A6feA8e7592A5d2bdd2DDc26a86D0fc24A",
     "decimals": "1e18",
     "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0xFA5Ed56A203466CbBC2430a43c66b9D8723528E7",
+      "oracle": "tokens",
+      "oracleId": "agEUR",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "oracle": "tokens",
+      "oracleId": "USDCe",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-arb-usdc.e",
+    "address": "0xd302119B5C46d504D0b3534312e56eC321976251",
+    "gauge": "0x559102b8CfbE64551177A9BE1e5E754a73C2BEE8",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "oracle": "tokens",
+      "oracleId": "ARB",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "oracle": "tokens",
+      "oracleId": "USDCe",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-rdnt-weth",
+    "address": "0x9aC09266B68a8Fea081C232e54fA31526E740570",
+    "gauge": "0x827d31D1Feb229999952995d7993Ec46b4c68006",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x3082CC23568eA640225c2467653dB90e9250AaA0",
+      "oracle": "tokens",
+      "oracleId": "RDNT",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "oracle": "tokens",
+      "oracleId": "WETH",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "chronos-weth-usdt",
+    "address": "0x8a263Cc1DfDCe6c64e2A1cf6133c22eED5D4E29d",
+    "gauge": "0xC4c063941Ba3b130f99769AB7e801ACB7b09E29F",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "oracle": "tokens",
+      "oracleId": "WETH",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "oracle": "tokens",
+      "oracleId": "USDT",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-weth-lusd",
+    "address": "0xc5b7AcC5Dc13679eb180702a1C40df1664b3078B",
+    "gauge": "0xE1b5E0394E2eED6685438e9aBafa8febA6E6122A",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "oracle": "tokens",
+      "oracleId": "WETH",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+      "oracle": "tokens",
+      "oracleId": "LUSD",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "chronos-weth-lqty",
+    "address": "0x393c93f8133bc89db3177D6e10182Efd4129D0d1",
+    "gauge": "0x5c2A7931A05BC7e5a8449B175cf265Ae09286A81",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "oracle": "tokens",
+      "oracleId": "WETH",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xfb9E5D956D889D91a82737B9bFCDaC1DCE3e1449",
+      "oracle": "tokens",
+      "oracleId": "LQTY",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "chronos-wbtc-weth",
+    "address": "0x5b69430721B580bB502af14d07001aC5de10aC6a",
+    "gauge": "0x9B27ef426e6618E32Ddd68628F939F620649bD9A",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+      "oracle": "tokens",
+      "oracleId": "WBTC",
+      "decimals": "1e8"
+    },
+    "lp1": {
+      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "oracle": "tokens",
+      "oracleId": "WETH",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "chronos-weth-reth",
+    "address": "0xBbBe4D4a3d370F478be7f2D3B734591BB1a99d37",
+    "gauge": "0x7c2278027B16Da1163f3CDeFC4D332B0db03b826",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "oracle": "tokens",
+      "oracleId": "WETH",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+      "oracle": "tokens",
+      "oracleId": "rETH",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "chronos-weth-bifi",
+    "address": "0x04c106eddDBe89f2Ed983f52020F33D126fA544b",
+    "gauge": "0xbD0cF21c20B5eb38B30e00f32893A80b5D823806",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
     "lp0": {
       "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
       "oracle": "tokens",
@@ -24,6 +185,7 @@
     "gauge": "0x2497Ec308CA75201B6f59F6970f33F9aEb63BA6c",
     "decimals": "1e18",
     "chainId": 42161,
+    "beefyFee": 0.095,
     "lp0": {
       "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
       "oracle": "tokens",
@@ -43,6 +205,7 @@
     "gauge": "0xdb74aE9C3d1b96326BDAb8E1da9c5e98281d576e",
     "decimals": "1e18",
     "chainId": 42161,
+    "beefyFee": 0.095,
     "lp0": {
       "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
       "oracle": "tokens",
@@ -52,7 +215,7 @@
     "lp1": {
       "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "oracle": "tokens",
-      "oracleId": "USDC",
+      "oracleId": "USDCe",
       "decimals": "1e6"
     }
   },
@@ -62,6 +225,7 @@
     "gauge": "0x7863bcC83fA7008CB421118AC05bFe7D5Ad5bBf1",
     "decimals": "1e18",
     "chainId": 42161,
+    "beefyFee": 0.095,
     "lp0": {
       "address": "0xDDc0385169797937066bBd8EF409b5B3c0dFEB52",
       "oracle": "tokens",
@@ -71,7 +235,7 @@
     "lp1": {
       "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "oracle": "tokens",
-      "oracleId": "USDC",
+      "oracleId": "USDCe",
       "decimals": "1e6"
     }
   },
@@ -81,6 +245,7 @@
     "gauge": "0x3d34022f552362a25A529EC6AF7B9cb226b9C22D",
     "decimals": "1e18",
     "chainId": 42161,
+    "beefyFee": 0.095,
     "lp0": {
       "address": "0x15b2fb8f08E4Ac1Ce019EADAe02eE92AeDF06851",
       "oracle": "tokens",
@@ -90,7 +255,7 @@
     "lp1": {
       "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "oracle": "tokens",
-      "oracleId": "USDC",
+      "oracleId": "USDCe",
       "decimals": "1e6"
     }
   }

--- a/src/data/arbitrum/chronosLpPools.json
+++ b/src/data/arbitrum/chronosLpPools.json
@@ -1,25 +1,5 @@
 [
   {
-    "name": "chronos-ageur-usdc.e",
-    "address": "0x0DEf5c34285b67d9f7467129FD522D0818b45E31",
-    "gauge": "0x911f73A6feA8e7592A5d2bdd2DDc26a86D0fc24A",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0xFA5Ed56A203466CbBC2430a43c66b9D8723528E7",
-      "oracle": "tokens",
-      "oracleId": "agEUR",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
-      "oracle": "tokens",
-      "oracleId": "USDCe",
-      "decimals": "1e6"
-    }
-  },
-  {
     "name": "chronos-arb-usdc.e",
     "address": "0xd302119B5C46d504D0b3534312e56eC321976251",
     "gauge": "0x559102b8CfbE64551177A9BE1e5E754a73C2BEE8",
@@ -60,46 +40,6 @@
     }
   },
   {
-    "name": "chronos-weth-usdt",
-    "address": "0x8a263Cc1DfDCe6c64e2A1cf6133c22eED5D4E29d",
-    "gauge": "0xC4c063941Ba3b130f99769AB7e801ACB7b09E29F",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
-      "oracle": "tokens",
-      "oracleId": "WETH",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
-      "oracle": "tokens",
-      "oracleId": "USDT",
-      "decimals": "1e6"
-    }
-  },
-  {
-    "name": "chronos-weth-lusd",
-    "address": "0xc5b7AcC5Dc13679eb180702a1C40df1664b3078B",
-    "gauge": "0xE1b5E0394E2eED6685438e9aBafa8febA6E6122A",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
-      "oracle": "tokens",
-      "oracleId": "WETH",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
-      "oracle": "tokens",
-      "oracleId": "LUSD",
-      "decimals": "1e18"
-    }
-  },
-  {
     "name": "chronos-weth-lqty",
     "address": "0x393c93f8133bc89db3177D6e10182Efd4129D0d1",
     "gauge": "0x5c2A7931A05BC7e5a8449B175cf265Ae09286A81",
@@ -116,26 +56,6 @@
       "address": "0xfb9E5D956D889D91a82737B9bFCDaC1DCE3e1449",
       "oracle": "tokens",
       "oracleId": "LQTY",
-      "decimals": "1e18"
-    }
-  },
-  {
-    "name": "chronos-wbtc-weth",
-    "address": "0x5b69430721B580bB502af14d07001aC5de10aC6a",
-    "gauge": "0x9B27ef426e6618E32Ddd68628F939F620649bD9A",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
-      "oracle": "tokens",
-      "oracleId": "WBTC",
-      "decimals": "1e8"
-    },
-    "lp1": {
-      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
-      "oracle": "tokens",
-      "oracleId": "WETH",
       "decimals": "1e18"
     }
   },

--- a/src/data/arbitrum/chronosStableLpPools.json
+++ b/src/data/arbitrum/chronosStableLpPools.json
@@ -1,65 +1,5 @@
 [
   {
-    "name": "chronos-jeur-ageur",
-    "address": "0x11357D693D8dfdFa570C3b899FBa073152f9dcAC",
-    "gauge": "0xbC84f92A391e7ae22B8D8980A0CE566314Bc2552",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0xAD435674417520aeeED6b504bBe654d4f556182F",
-      "oracle": "tokens",
-      "oracleId": "jEUR",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xFA5Ed56A203466CbBC2430a43c66b9D8723528E7",
-      "oracle": "tokens",
-      "oracleId": "agEUR",
-      "decimals": "1e18"
-    }
-  },
-  {
-    "name": "chronos-usdt-usdc.e",
-    "address": "0xC9445A9AFe8E48c71459aEdf956eD950e983eC5A",
-    "gauge": "0x026acD3425132870986561b7e3f2f15f5920E119",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
-      "oracle": "tokens",
-      "oracleId": "USDT",
-      "decimals": "1e6"
-    },
-    "lp1": {
-      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
-      "oracle": "tokens",
-      "oracleId": "USDCe",
-      "decimals": "1e6"
-    }
-  },
-  {
-    "name": "chronos-dai-usdc.e",
-    "address": "0xfd1e3458C7a1D3506f5cC6180A53F1e60f9D6BEa",
-    "gauge": "0xd3B8DE04b90b4BaE249E5F0b30ae98d7F02b6DAb",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
-      "oracle": "tokens",
-      "oracleId": "DAI",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
-      "oracle": "tokens",
-      "oracleId": "USDCe",
-      "decimals": "1e6"
-    }
-  },
-  {
     "name": "chronos-frax-usd+",
     "address": "0x0D20EF7033b73Ea0c9c320304B05da82E2C14E33",
     "gauge": "0xaF618E6F5EF781e3aCFe00708BD005E0cc9A2e6F",
@@ -76,66 +16,6 @@
       "address": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
       "oracle": "tokens",
       "oracleId": "oUSD+",
-      "decimals": "1e6"
-    }
-  },
-  {
-    "name": "chronos-dola-usd+",
-    "address": "0xBbD7fF1728963A5Eb582d26ea90290F84E89bd66",
-    "gauge": "0x3004F018B2C01d40D19C7dC4a5a0AFA8743a7e24",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6",
-      "oracle": "tokens",
-      "oracleId": "DOLA",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
-      "oracle": "tokens",
-      "oracleId": "oUSD+",
-      "decimals": "1e6"
-    }
-  },
-  {
-    "name": "chronos-lusd-usd+",
-    "address": "0xcd78e225E36E724c9FB4Bd8287296557D728cda7",
-    "gauge": "0x7de0998eE1Fce80c160AD1F5Fe768BFF9b0ee87f",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
-      "oracle": "tokens",
-      "oracleId": "LUSD",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
-      "oracle": "tokens",
-      "oracleId": "oUSD+",
-      "decimals": "1e6"
-    }
-  },
-  {
-    "name": "chronos-lusd-usdt",
-    "address": "0x5F4f21D9159b6139793c78aD8F17b6B7f93b75E7",
-    "gauge": "0x5a12C3881552851eD61CBADc6a5e19579C414A16",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
-      "oracle": "tokens",
-      "oracleId": "LUSD",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
-      "oracle": "tokens",
-      "oracleId": "USDT",
       "decimals": "1e6"
     }
   },
@@ -160,66 +40,6 @@
     }
   },
   {
-    "name": "chronos-frxeth-sfrxeth",
-    "address": "0xd52862915de98201bA93a45E73081450075C4E33",
-    "gauge": "0x548e0D4Fcb6b82a025E6770066b4127C5FCcBF07",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x178412e79c25968a32e89b11f63B33F733770c2A",
-      "oracle": "tokens",
-      "oracleId": "frxETH",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0x95aB45875cFFdba1E5f451B950bC2E42c0053f39",
-      "oracle": "tokens",
-      "oracleId": "sfrxETH",
-      "decimals": "1e18"
-    }
-  },
-  {
-    "name": "chronos-frxeth-weth",
-    "address": "0xdb286ED48b294D348593bFAf1f862393FA8776e9",
-    "gauge": "0x9A028F3Dd7067479b51ee89CDb0Db594744ebfAd",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x178412e79c25968a32e89b11f63B33F733770c2A",
-      "oracle": "tokens",
-      "oracleId": "frxETH",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
-      "oracle": "tokens",
-      "oracleId": "WETH",
-      "decimals": "1e18"
-    }
-  },
-  {
-    "name": "chronos-frax-mai",
-    "address": "0x37A7bF05807feCD6b1CCE53366059e70E313e4Af",
-    "gauge": "0x1371512f45d85e6247aBfA2926Ac5213324a6BEB",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
-      "oracle": "tokens",
-      "oracleId": "FRAX",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0x3F56e0c36d275367b8C502090EDF38289b3dEa0d",
-      "oracle": "tokens",
-      "oracleId": "MAI",
-      "decimals": "1e18"
-    }
-  },
-  {
     "name": "chronos-mai-lusd",
     "address": "0x97cdc9e5DF1afa297Ac24Ce8c0b7b6a9A2cf7448",
     "gauge": "0xc7F5AAE3A39217172875Ba3F72dB12101bd89519",
@@ -236,26 +56,6 @@
       "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
       "oracle": "tokens",
       "oracleId": "LUSD",
-      "decimals": "1e18"
-    }
-  },
-  {
-    "name": "chronos-usd+-dai+",
-    "address": "0xB260163158311596Ea88a700C5a30f101D072326",
-    "gauge": "0xCD4A56221175b88d4fb28CA2138d670Cc1197CA9",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
-      "oracle": "tokens",
-      "oracleId": "oUSD+",
-      "decimals": "1e6"
-    },
-    "lp1": {
-      "address": "0xeb8E93A0c7504Bffd8A8fFa56CD754c63aAeBFe8",
-      "oracle": "tokens",
-      "oracleId": "oUSD+",
       "decimals": "1e18"
     }
   }

--- a/src/data/arbitrum/chronosStableLpPools.json
+++ b/src/data/arbitrum/chronosStableLpPools.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "chronos-jeur-ageur",
+    "address": "0x11357D693D8dfdFa570C3b899FBa073152f9dcAC",
+    "gauge": "0xbC84f92A391e7ae22B8D8980A0CE566314Bc2552",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0xAD435674417520aeeED6b504bBe654d4f556182F",
+      "oracle": "tokens",
+      "oracleId": "jEUR",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xFA5Ed56A203466CbBC2430a43c66b9D8723528E7",
+      "oracle": "tokens",
+      "oracleId": "agEUR",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "chronos-usdt-usdc.e",
     "address": "0xC9445A9AFe8E48c71459aEdf956eD950e983eC5A",
     "gauge": "0x026acD3425132870986561b7e3f2f15f5920E119",

--- a/src/data/arbitrum/chronosStableLpPools.json
+++ b/src/data/arbitrum/chronosStableLpPools.json
@@ -1,45 +1,5 @@
 [
   {
-    "name": "chronos-frax-usd+",
-    "address": "0x0D20EF7033b73Ea0c9c320304B05da82E2C14E33",
-    "gauge": "0xaF618E6F5EF781e3aCFe00708BD005E0cc9A2e6F",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
-      "oracle": "tokens",
-      "oracleId": "FRAX",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
-      "oracle": "tokens",
-      "oracleId": "oUSD+",
-      "decimals": "1e6"
-    }
-  },
-  {
-    "name": "chronos-lusd-usdc.e",
-    "address": "0x4F7ecB899871114F75c052D94a74ebd316f20660",
-    "gauge": "0x1b918A614612D6F94Fd3da7aD354480ecB3c5aAa",
-    "decimals": "1e18",
-    "chainId": 42161,
-    "beefyFee": 0.095,
-    "lp0": {
-      "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
-      "oracle": "tokens",
-      "oracleId": "LUSD",
-      "decimals": "1e18"
-    },
-    "lp1": {
-      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
-      "oracle": "tokens",
-      "oracleId": "USDCe",
-      "decimals": "1e6"
-    }
-  },
-  {
     "name": "chronos-mai-lusd",
     "address": "0x97cdc9e5DF1afa297Ac24Ce8c0b7b6a9A2cf7448",
     "gauge": "0xc7F5AAE3A39217172875Ba3F72dB12101bd89519",

--- a/src/data/arbitrum/chronosStableLpPools.json
+++ b/src/data/arbitrum/chronosStableLpPools.json
@@ -1,0 +1,242 @@
+[
+  {
+    "name": "chronos-usdt-usdc.e",
+    "address": "0xC9445A9AFe8E48c71459aEdf956eD950e983eC5A",
+    "gauge": "0x026acD3425132870986561b7e3f2f15f5920E119",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "oracle": "tokens",
+      "oracleId": "USDT",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "oracle": "tokens",
+      "oracleId": "USDCe",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-dai-usdc.e",
+    "address": "0xfd1e3458C7a1D3506f5cC6180A53F1e60f9D6BEa",
+    "gauge": "0xd3B8DE04b90b4BaE249E5F0b30ae98d7F02b6DAb",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+      "oracle": "tokens",
+      "oracleId": "DAI",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "oracle": "tokens",
+      "oracleId": "USDCe",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-frax-usd+",
+    "address": "0x0D20EF7033b73Ea0c9c320304B05da82E2C14E33",
+    "gauge": "0xaF618E6F5EF781e3aCFe00708BD005E0cc9A2e6F",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
+      "oracle": "tokens",
+      "oracleId": "FRAX",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
+      "oracle": "tokens",
+      "oracleId": "oUSD+",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-dola-usd+",
+    "address": "0xBbD7fF1728963A5Eb582d26ea90290F84E89bd66",
+    "gauge": "0x3004F018B2C01d40D19C7dC4a5a0AFA8743a7e24",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6",
+      "oracle": "tokens",
+      "oracleId": "DOLA",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
+      "oracle": "tokens",
+      "oracleId": "oUSD+",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-lusd-usd+",
+    "address": "0xcd78e225E36E724c9FB4Bd8287296557D728cda7",
+    "gauge": "0x7de0998eE1Fce80c160AD1F5Fe768BFF9b0ee87f",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+      "oracle": "tokens",
+      "oracleId": "LUSD",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
+      "oracle": "tokens",
+      "oracleId": "oUSD+",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-lusd-usdt",
+    "address": "0x5F4f21D9159b6139793c78aD8F17b6B7f93b75E7",
+    "gauge": "0x5a12C3881552851eD61CBADc6a5e19579C414A16",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+      "oracle": "tokens",
+      "oracleId": "LUSD",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "oracle": "tokens",
+      "oracleId": "USDT",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-lusd-usdc.e",
+    "address": "0x4F7ecB899871114F75c052D94a74ebd316f20660",
+    "gauge": "0x1b918A614612D6F94Fd3da7aD354480ecB3c5aAa",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+      "oracle": "tokens",
+      "oracleId": "LUSD",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "oracle": "tokens",
+      "oracleId": "USDCe",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "chronos-frxeth-sfrxeth",
+    "address": "0xd52862915de98201bA93a45E73081450075C4E33",
+    "gauge": "0x548e0D4Fcb6b82a025E6770066b4127C5FCcBF07",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x178412e79c25968a32e89b11f63B33F733770c2A",
+      "oracle": "tokens",
+      "oracleId": "frxETH",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x95aB45875cFFdba1E5f451B950bC2E42c0053f39",
+      "oracle": "tokens",
+      "oracleId": "sfrxETH",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "chronos-frxeth-weth",
+    "address": "0xdb286ED48b294D348593bFAf1f862393FA8776e9",
+    "gauge": "0x9A028F3Dd7067479b51ee89CDb0Db594744ebfAd",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x178412e79c25968a32e89b11f63B33F733770c2A",
+      "oracle": "tokens",
+      "oracleId": "frxETH",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "oracle": "tokens",
+      "oracleId": "WETH",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "chronos-frax-mai",
+    "address": "0x37A7bF05807feCD6b1CCE53366059e70E313e4Af",
+    "gauge": "0x1371512f45d85e6247aBfA2926Ac5213324a6BEB",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
+      "oracle": "tokens",
+      "oracleId": "FRAX",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x3F56e0c36d275367b8C502090EDF38289b3dEa0d",
+      "oracle": "tokens",
+      "oracleId": "MAI",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "chronos-mai-lusd",
+    "address": "0x97cdc9e5DF1afa297Ac24Ce8c0b7b6a9A2cf7448",
+    "gauge": "0xc7F5AAE3A39217172875Ba3F72dB12101bd89519",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x3F56e0c36d275367b8C502090EDF38289b3dEa0d",
+      "oracle": "tokens",
+      "oracleId": "MAI",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+      "oracle": "tokens",
+      "oracleId": "LUSD",
+      "decimals": "1e18"
+    }
+  },
+  {
+    "name": "chronos-usd+-dai+",
+    "address": "0xB260163158311596Ea88a700C5a30f101D072326",
+    "gauge": "0xCD4A56221175b88d4fb28CA2138d670Cc1197CA9",
+    "decimals": "1e18",
+    "chainId": 42161,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
+      "oracle": "tokens",
+      "oracleId": "oUSD+",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0xeb8E93A0c7504Bffd8A8fFa56CD754c63aAeBFe8",
+      "oracle": "tokens",
+      "oracleId": "oUSD+",
+      "decimals": "1e18"
+    }
+  }
+]


### PR DESCRIPTION
- ARB-USDC.e vLP `chronos-arb-usdc.e` 6.1% (vs 6.0%)
- RDNT-ETH vLP `chronos-rdnt-weth` 9.8% (vs 3.2%)
- rETH-ETH vLP `chronos-weth-reth` 6.0% (vs 5.9%)
- MAI-LUSD sLP `chronos-mai-lusd` 12% (vs 3.5%)
- ETH-LQTY vLP `chronos-weth-lqty` 10% (vs 5.7%)

Also adds `arb:chronos:add` command, sets correct Beefy fees, switches to USDCe oracle ID, and fixes type bug (`bool` → `boolean`).