### PR TITLE
Add RDNT-BNB PCS Farm + RDNT Token for BSC

### DIFF
--- a/packages/address-book/address-book/bsc/tokens/tokens.ts
+++ b/packages/address-book/address-book/bsc/tokens/tokens.ts
@@ -4119,5 +4119,16 @@ const _tokens = {
       'Venus wrapped USDT. Venus is an algorithmic money market and synthetic stablecoin protocol launched exclusively on BNB Chain.',
     logoURI: '',
   },
+  RDNT: {
+    name: 'RDNT',
+    symbol: 'RDNT',
+    address: '0xf7DE7E8A6bd59ED41a4b5fe50278b3B7f31384dF',
+    chainId: 56,
+    decimals: 18,
+    website: 'https://radiant.capital/',
+    description:
+      'Radiant aims to be the first omnichain money market, where users can deposit any major asset on any major chain and borrow a variety of supported assets across multiple chains.',
+    logoURI: '',
+  },
 } as const;
 export const tokens: ConstRecord<typeof _tokens, Token> = _tokens;

--- a/src/data/cakeLpPoolsV2.json
+++ b/src/data/cakeLpPoolsV2.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "cakev2-wbnb-rdnt",
+    "address": "0x346575fC7f07E6994D76199E41D13dC1575322E1",
+    "decimals": "1e18",
+    "beefyFee": 0.095,
+    "poolId": 160,
+    "chainId": 56,
+    "lp0": {
+      "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "oracle": "tokens",
+      "oracleId": "WBNB",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xf7DE7E8A6bd59ED41a4b5fe50278b3B7f31384dF",
+      "oracle": "tokens",
+      "oracleId": "RDNT",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "cakev2-id-usdt",
     "address": "0x9Ed9E9aA51670A3210fD6078024c21ec6c1d61d9",
     "decimals": "1e18",


### PR DESCRIPTION
Proposal to add an RDNT-BNB vault on PancakeSwap. 240k locked on PCS, 18M total liquidity in the pool (most of it locked on Radiant)