### PR TITLE
Add Extra Rewards (BVM/FVM/CVM)

### DIFF
--- a/packages/address-book/address-book/base/tokens/tokens.ts
+++ b/packages/address-book/address-book/base/tokens/tokens.ts
@@ -18,6 +18,34 @@ const _tokens = {
   ETH,
   WETH: ETH,
   WNATIVE: ETH,
+  'USD+': {
+    name: 'USD+',
+    symbol: 'USD+',
+    address: '0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376',
+    chainId: 8453,
+    decimals: 6,
+    logoURI:
+      'https://tokens.pancakeswap.finance/images/0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376.svg',
+    website: 'https://overnight.fi/',
+    description:
+      'USD+ is USDC that pays you yield daily via rebase. It is 100% collateralized with assets immediately convertible into USDC. Yield is generated via strategies such as lending and stable-to-stable pools. Initial strategies include Aave, Rubicon, and Pika.',
+    documentation: 'https://docs.overnight.fi/',
+    bridge: 'native',
+  },
+  'DAI+': {
+    name: 'DAI+',
+    symbol: 'DAI+',
+    address: '0x65a2508C429a6078a7BC2f7dF81aB575BD9D9275',
+    chainId: 8453,
+    decimals: 18,
+    logoURI:
+      'https://tokens.pancakeswap.finance/images/0x65a2508C429a6078a7BC2f7dF81aB575BD9D9275.svg',
+    website: 'https://overnight.fi/',
+    description:
+      'DAI+ is DAI that pays you yield daily via rebase.  It is 100% collateralized with assets immediately convertible into DAI.  Yield is generated via strategies such as lending and stable-to-stable pools. Initial strategies include Aave, Rubicon, and Pika.',
+    documentation: 'https://docs.overnight.fi/',
+    bridge: 'native',
+  },
   MIM: {
     name: 'Magic Internet Money',
     symbol: 'MIM',

--- a/src/api/stats/base/getBvmApys.js
+++ b/src/api/stats/base/getBvmApys.js
@@ -1,15 +1,12 @@
 const { BASE_CHAIN_ID: chainId } = require('../../../constants');
 const { getSolidlyGaugeApys } = require('../common/getSolidlyGaugeApys');
 
+const stablePools = require('../../../data/base/bvmStableLpPools.json');
 const volatilePools = require('../../../data/base/bvmLpPools.json');
 import { addressBook } from '../../../../packages/address-book/address-book';
-const {
-  base: {
-    tokens: { BVM },
-  },
-} = addressBook;
+const { BVM } = addressBook.base.tokens;
 
-const pools = [...volatilePools];
+const pools = [...stablePools, ...volatilePools];
 const getBvmApys = async () =>
   getSolidlyGaugeApys({
     chainId: chainId,
@@ -18,7 +15,6 @@ const getBvmApys = async () =>
     oracle: 'tokens',
     decimals: '1e18',
     reward: BVM.address,
-    boosted: false,
     // log: true,
   });
 

--- a/src/api/stats/base/getBvmStablePrices.js
+++ b/src/api/stats/base/getBvmStablePrices.js
@@ -1,0 +1,9 @@
+const getSolidlyStablePrices = require('../common/getSolidlyStablePrices');
+const pools = require('../../../data/base/bvmStableLpPools.json');
+const { BASE_CHAIN_ID } = require('../../../constants');
+
+const getBvmStablePrices = async tokenPrices => {
+  return await getSolidlyStablePrices(BASE_CHAIN_ID, pools, tokenPrices);
+};
+
+module.exports = getBvmStablePrices;

--- a/src/api/stats/canto/getCvmApys.js
+++ b/src/api/stats/canto/getCvmApys.js
@@ -3,11 +3,7 @@ const { getSolidlyGaugeApys } = require('../common/getSolidlyGaugeApys');
 
 const volatilePools = require('../../../data/canto/cvmLpPools.json');
 import { addressBook } from '../../../../packages/address-book/address-book';
-const {
-  canto: {
-    tokens: { CVM },
-  },
-} = addressBook;
+const { CVM } = addressBook.canto.tokens;
 
 const pools = [...volatilePools];
 const getCvmApys = async () =>
@@ -18,7 +14,6 @@ const getCvmApys = async () =>
     oracle: 'tokens',
     decimals: '1e18',
     reward: CVM.address,
-    boosted: false,
     // log: true,
   });
 

--- a/src/api/stats/fantom/getFvmApys.js
+++ b/src/api/stats/fantom/getFvmApys.js
@@ -4,11 +4,7 @@ const { getSolidlyGaugeApys } = require('../common/getSolidlyGaugeApys');
 const stablePools = require('../../../data/fantom/fvmStableLpPools.json');
 const volatilePools = require('../../../data/fantom/fvmLpPools.json');
 import { addressBook } from '../../../../packages/address-book/address-book';
-const {
-  fantom: {
-    tokens: { FVM },
-  },
-} = addressBook;
+const { FVM } = addressBook.fantom.tokens;
 
 const pools = [...stablePools, ...volatilePools];
 const getFvmApys = async () =>
@@ -19,7 +15,6 @@ const getFvmApys = async () =>
     oracle: 'tokens',
     decimals: '1e18',
     reward: FVM.address,
-    boosted: false,
     // log: true,
   });
 

--- a/src/api/stats/getNonAmmPrices.ts
+++ b/src/api/stats/getNonAmmPrices.ts
@@ -76,6 +76,7 @@ import getQuickGammaPrices from './matic/getQuickGammaPrices';
 import getChronosStablePrices from './arbitrum/getChronosStablePrices';
 import getQuickGammaZkPrices from './zkevm/getQuickGammaPrices';
 import getFvmStablePrices from './fantom/getFvmStablePrices';
+import getBvmStablePrices from './base/getBvmStablePrices';
 import getRetroGammaPrices from './matic/getRetroGammaPrices';
 import { getQlpZkPrices } from './zkevm/getQlpZkPrices';
 import getUniswapGammaPrices from './optimism/getUniswapGammaPrices';
@@ -182,6 +183,7 @@ export async function getNonAmmPrices(tokenPrices: Record<string, number>): Prom
     getQuickGammaZkPrices(tokenPrices),
     getChronosStablePrices(tokenPrices),
     getFvmStablePrices(tokenPrices),
+    getBvmStablePrices(tokenPrices),
     getQlpZkPrices(tokenPrices),
   ];
 

--- a/src/data/base/bvmLpPools.json
+++ b/src/data/base/bvmLpPools.json
@@ -46,6 +46,13 @@
     "decimals": "1e18",
     "chainId": 8453,
     "beefyFee": 0.095,
+    "rewards": [
+      {
+        "address": "0x4200000000000000000000000000000000000006",
+        "oracleId": "WETH",
+        "decimals": "1e18"
+      }
+    ],
     "lp0": {
       "address": "0x4200000000000000000000000000000000000006",
       "oracle": "tokens",

--- a/src/data/base/bvmStableLpPools.json
+++ b/src/data/base/bvmStableLpPools.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "bvm-usd+-usdbc",
+    "address": "0x653685aA9913C6aB13d659A4Ea8F358eceC3D34f",
+    "gauge": "0xD9875fBe2A706f9Fed68F066D7420D63FDC5eD76",
+    "decimals": "1e18",
+    "chainId": 8453,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376",
+      "oracle": "tokens",
+      "oracleId": "USD+",
+      "decimals": "1e6"
+    },
+    "lp1": {
+      "address": "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
+      "oracle": "tokens",
+      "oracleId": "USDbC",
+      "decimals": "1e6"
+    }
+  },
+  {
+    "name": "bvm-dai+-usd+",
+    "address": "0x298C9f812c470598c5f97e3dA9261A9899b89d35",
+    "gauge": "0x0dAf00A383F8897553aC1d03F4445B15AfA1dcb9",
+    "decimals": "1e18",
+    "chainId": 8453,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x65a2508C429a6078a7BC2f7dF81aB575BD9D9275",
+      "oracle": "tokens",
+      "oracleId": "DAI+",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376",
+      "oracle": "tokens",
+      "oracleId": "USD+",
+      "decimals": "1e6"
+    }
+  }
+]

--- a/src/data/canto/cvmLpPools.json
+++ b/src/data/canto/cvmLpPools.json
@@ -6,6 +6,13 @@
     "decimals": "1e18",
     "chainId": 7700,
     "beefyFee": 0.095,
+    "rewards": [
+      {
+        "address": "0x9F823D534954Fc119E31257b3dDBa0Db9E2Ff4ed",
+        "oracleId": "sCANTO",
+        "decimals": "1e18"
+      }
+    ],
     "lp0": {
       "address": "0x9F823D534954Fc119E31257b3dDBa0Db9E2Ff4ed",
       "oracle": "tokens",

--- a/src/data/fantom/fvmLpPools.json
+++ b/src/data/fantom/fvmLpPools.json
@@ -46,6 +46,13 @@
     "decimals": "1e18",
     "chainId": 250,
     "beefyFee": 0.095,
+    "rewards": [
+      {
+        "address": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
+        "oracleId": "WFTM",
+        "decimals": "1e18"
+      }
+    ],
     "lp0": {
       "address": "0x07BB65fAaC502d4996532F834A1B7ba5dC32Ff96",
       "oracle": "tokens",


### PR DESCRIPTION
Found that `rewardData()` doesn't exist on the standard `ISolidlyGauge` ABI (used for BVM/FVM/CVM) which explains my adjustment there, I kept it backwards compatible to ensure the custom ABIs that use it such as `ISolidlyGaugeV2` will continue to work. Also did some minor cleanup refactoring to handle extra rewards.