### PR TITLE
Increase 1inch rate limit

### DIFF
--- a/src/api/zaps/one-inch/RateLimitedOneInchSwapApi.ts
+++ b/src/api/zaps/one-inch/RateLimitedOneInchSwapApi.ts
@@ -13,4 +13,12 @@ export class RateLimitedOneInchSwapApi extends OneInchSwapApi {
   ): Promise<ResponseType> {
     return this.queue.add(() => super.get(path, request));
   }
+
+  protected async transparentGet<RequestType extends {}>(
+    path: string,
+    request: RequestType
+  ): Promise<ProxiedResponse> {
+    // Rate limit, but higher priority than normal get, as these are used for app api proxy
+    return this.queue.add(() => super.transparentGet(path, request), { priority: 1 });
+  }
 }

--- a/src/api/zaps/one-inch/index.ts
+++ b/src/api/zaps/one-inch/index.ts
@@ -6,9 +6,9 @@ import { IOneInchPriceApi, IOneInchSwapApi } from './types';
 
 // Configure to just under RPS allowed by our account
 const API_QUEUE_CONFIG = {
-  concurrency: 1, // TODO change once we have enterprise account
-  intervalCap: 1, // TODO change once we have enterprise account
-  interval: 2000, // TODO change once we have enterprise account
+  concurrency: 10,
+  intervalCap: 10,
+  interval: 1000,
   carryoverConcurrencyCount: true,
   autoStart: true,
   timeout: 30 * 1000,


### PR DESCRIPTION
Also rate limits app requests which are proxied via api, but with higher priority than in-api requests (app requests will be queued ahead of the requests the api makes to check for liquidity)