### PR TITLE
Use oracleId field for MAI on Base

### DIFF
--- a/packages/address-book/address-book/base/tokens/tokens.ts
+++ b/packages/address-book/address-book/base/tokens/tokens.ts
@@ -323,9 +323,10 @@ const _tokens = {
       'Inverse.finance is a suite of permissionless decentralized finance tools governed by Inverse DAO, a decentralized autonomous organization running on the Ethereum blockchain.',
     bridge: 'base-canonical',
   },
-  bMAI: {
+  MAI: {
     name: 'Mai Stablecoin',
-    symbol: 'bMAI',
+    symbol: 'MAI',
+    oracleId: 'bMAI',
     address: '0xbf1aeA8670D2528E08334083616dD9C5F3B087aE',
     chainId: 8453,
     decimals: 18,


### PR DESCRIPTION
Experiment just adding `oracleId` to address book to change the oracle id of a token.

In app then we'd only need to change vault oracleId or boost earnedOracleId if the token was a deposit token for a vault or reward token for boost respectively.
The vault's assets[] array wouldn't need changed and no duplicate token image would need added as the token's id would stay the same.