### PR TITLE
Check addressbook for duplicate addresses with different oracles

### DIFF
--- a/packages/address-book/address-book/avax/tokens/tokens.ts
+++ b/packages/address-book/address-book/avax/tokens/tokens.ts
@@ -4657,7 +4657,7 @@ const _tokens = {
     chainId: 43114,
     name: 'Pangolin',
     symbol: 'PNG',
-    oracleId: 'PNG-Pangolin',
+    oracleId: 'PNG',
     website: 'https://pangolin.exchange/',
     description:
       'A community-driven decentralized exchange for Avalanche and Ethereum assets with fast settlement, low transaction fees, and a democratic distribution–powered by Avalanche. Pangolin brings you the best trading opportunities to find and maximize your yield.',

--- a/packages/address-book/address-book/celo/tokens/tokens.ts
+++ b/packages/address-book/address-book/celo/tokens/tokens.ts
@@ -117,7 +117,7 @@ const _tokens = {
   DAI: {
     name: 'Dai Stablecoin',
     symbol: 'DAI',
-    oracleId: 'DAI',
+    oracleId: 'DAIV1',
     address: '0xE4fE50cdD716522A56204352f00AA110F731932d',
     chainId: 42220,
     decimals: 18,

--- a/packages/address-book/address-book/moonbeam/tokens/tokens.ts
+++ b/packages/address-book/address-book/moonbeam/tokens/tokens.ts
@@ -621,7 +621,7 @@ const _tokens = {
   UST: {
     name: 'Axelar Wrapped UST',
     symbol: 'UST',
-    oracleId: 'UST',
+    oracleId: 'axlUST',
     address: '0x085416975fe14C2A731a97eC38B9bF8135231F62',
     chainId: 1284,
     decimals: 6,

--- a/packages/address-book/package.json
+++ b/packages/address-book/package.json
@@ -17,6 +17,7 @@
     "checksummify": "ts-node ./scripts/toChecksumTokenList.ts",
     "checkDecimals": "ts-node --transpileOnly ./scripts/checkDecimals.ts",
     "checkOracleId": "ts-node --transpileOnly ./scripts/checkOracleId.ts",
+    "checkDuplicates": "ts-node --transpileOnly ./scripts/checkDuplicates.ts",
     "submit": "yarn checksum && yarn compile && yarn publish"
   },
   "devDependencies": {

--- a/packages/address-book/scripts/checkDuplicates.ts
+++ b/packages/address-book/scripts/checkDuplicates.ts
@@ -1,0 +1,56 @@
+import { addressBook } from '../address-book';
+import Token from '../types/token';
+
+type ChainId = keyof typeof addressBook;
+type TokenWithId = Token & { id: string };
+const allChains = Object.keys(addressBook) as ChainId[];
+
+async function checkChain(chainId: ChainId) {
+  const { tokens } = addressBook[chainId];
+  const byAddress: Record<string, TokenWithId[]> = {};
+
+  for (const [id, token] of Object.entries(tokens)) {
+    const key = token.address.toLowerCase();
+    if (!byAddress[key]) {
+      byAddress[key] = [];
+    }
+    byAddress[key].push({
+      ...token,
+      id,
+    });
+  }
+
+  let errors = 0;
+  for (const [address, duplicates] of Object.entries(byAddress)) {
+    if (duplicates.length > 1 && duplicates[0].address !== tokens.WNATIVE.address) {
+      console.warn(
+        `[WARN] Duplicate address ${address} on ${chainId}: ${duplicates
+          .map(t => `${t.id} (${t.oracleId})`)
+          .join(', ')}`
+      );
+      const uniqueOracles = Array.from(new Set(duplicates.map(t => t.oracleId)));
+      if (uniqueOracles.length > 1) {
+        console.error(
+          `[ERROR] Different oracleIds for ${address} on ${chainId}: ${uniqueOracles.join(', ')}`
+        );
+        ++errors;
+      }
+    }
+  }
+
+  return errors;
+}
+
+async function start() {
+  const errors = (await Promise.all(allChains.map(checkChain))).reduce((acc, e) => acc + e, 0);
+  if (errors > 0) {
+    throw new Error(`Found ${errors} errors, see above`);
+  }
+}
+
+start()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error(err);
+    process.exit(-1);
+  });


### PR DESCRIPTION
Script ignores duplicate entries for WNATIVE.
Produces warnings for duplicate addresses and errors when those duplicates have different `oracleId`s
```
[WARN] Duplicate address 0xa3fa99a148fa48d14ed51d610c367c61876997f1 on polygon: MAI (MAI), miMATIC (MAI)
[WARN] Duplicate address 0x60781c2586d68229fde47564546784ab3faca982 on avax: PNG (PNG), PNG-Pangolin (PNG-Pangolin)
[ERROR] Different oracleIds for 0x60781c2586d68229fde47564546784ab3faca982 on avax: PNG, PNG-Pangolin
[WARN] Duplicate address 0x321162cd933e2be498cd2267a90534a804051b11 on fantom: WBTC (fmcBTC), BTC (fmcBTC)
[WARN] Duplicate address 0x74b23882a30290451a17c44f4f05243b6b58c76d on fantom: WETH (fmcETH), ETH (fmcETH)
[WARN] Duplicate address 0xbec775cb42abfa4288de81f387a9b1a3c4bc552a on one: SUSHI (SUSHI), oneSUSHI (SUSHI)
[WARN] Duplicate address 0xe4fe50cdd716522a56204352f00aa110f731932d on celo: DAIV1 (DAIV1), DAI (DAI)
[ERROR] Different oracleIds for 0xe4fe50cdd716522a56204352f00aa110f731932d on celo: DAIV1, DAI
[WARN] Duplicate address 0xd15ec721c2a896512ad29c671997dd68f9593226 on celo: SUSHIV1 (SUSHI), cSUSHI (SUSHI)
[WARN] Duplicate address 0xf50225a84382c74cbdea10b0c176f71fc3de0c4d on moonriver: WMOVR_SUSHI (WMOVR), WNATIVE_SUSHI (WMOVR)
[WARN] Duplicate address 0xf390830df829cf22c53c8840554b98eafc5dcbc2 on moonriver: SUSHI (SUSHI), mSUSHI (SUSHI)
[WARN] Duplicate address 0x085416975fe14c2a731a97ec38b9bf8135231f62 on moonbeam: axlUST (axlUST), UST (UST)
[ERROR] Different oracleIds for 0x085416975fe14c2a731a97ec38b9bf8135231f62 on moonbeam: axlUST, UST
```

Applied fixes:
`PNG-Pangolin` on avax - set oracleId to `PNG`
`DAI` on celo - set oracleId to `DAIV1`
`UST` on moonbeam - set oracleId to `axlUST`
