### PR TITLE
Add string arg to fetchPrice for easier debugging of missing prices

### DIFF
--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -873,7 +873,7 @@ export async function getLpBreakdownForOracle(oracleId: string) {
 
 export async function getAmmTokenPrice(
   oracleId: string,
-  withUnknownLogging: boolean = false
+  withUnknownLogging: boolean | string = false
 ): Promise<number | undefined> {
   const tokenPrices = await getAmmTokensPrices();
   if (tokenPrices.hasOwnProperty(oracleId)) {
@@ -881,15 +881,17 @@ export async function getAmmTokenPrice(
   }
 
   if (withUnknownLogging) {
-    console.log(
-      `Unknown oracleId '${oracleId}' in tokens oracle. Consider adding it to .json file`
+    console.warn(
+      `Unknown oracleId '${oracleId}' in tokens oracle. ${
+        withUnknownLogging === true ? 'Consider adding it to .json file' : withUnknownLogging
+      }`
     );
   }
 }
 
 export async function getAmmLpPrice(
   oracleId: string,
-  withUnknownLogging: boolean = false
+  withUnknownLogging: boolean | string = false
 ): Promise<number | undefined> {
   const lpPrices = await getAmmLpPrices();
   if (lpPrices.hasOwnProperty(oracleId)) {
@@ -897,13 +899,17 @@ export async function getAmmLpPrice(
   }
 
   if (withUnknownLogging) {
-    console.log(`Unknown oracleId '${oracleId}' in lps oracle. Consider adding it to .json file`);
+    console.warn(
+      `Unknown oracleId '${oracleId}' in lps oracle. ${
+        withUnknownLogging === true ? 'Consider adding it to .json file' : withUnknownLogging
+      }`
+    );
   }
 }
 
 export async function getAmmPrice(
   oracleId: string,
-  withUnknownLogging: boolean = false
+  withUnknownLogging: boolean | string = false
 ): Promise<number | undefined> {
   const allPrices = await getAmmAllPrices();
   if (allPrices.hasOwnProperty(oracleId)) {
@@ -911,7 +917,11 @@ export async function getAmmPrice(
   }
 
   if (withUnknownLogging) {
-    console.error(`Unknown oracleId '${oracleId}' in any oracle. Consider adding it to .json file`);
+    console.warn(
+      `Unknown oracleId '${oracleId}' in any oracle. ${
+        withUnknownLogging === true ? 'Consider adding it to .json file' : withUnknownLogging
+      }`
+    );
   }
 }
 

--- a/src/api/stats/getMooTokenPrices.ts
+++ b/src/api/stats/getMooTokenPrices.ts
@@ -16,7 +16,10 @@ const updateMooTokenPrices = async () => {
   let vaults = getMultichainVaults();
   for (const vault of vaults) {
     try {
-      let price = await fetchPrice({ oracle: vault.oracle, id: vault.oracleId });
+      let price = await fetchPrice(
+        { oracle: vault.oracle, id: vault.oracleId },
+        `oracleId of ${vault.id} on ${vault.chain} in updateMooTokenPrices`
+      );
       const mooPrice = vault.pricePerFullShare.times(price).dividedBy(1e18);
 
       if (mooPrice) {

--- a/src/utils/fetchPrice.ts
+++ b/src/utils/fetchPrice.ts
@@ -24,7 +24,10 @@ export type FetchPriceParams = FetchPriceOracleParams | FetchPriceHardcodeParams
  * Fetches the price of a given oracle id.
  * @dev This function no longer has a built-in cache as the underlying getAmmXPrice functions already have one.
  */
-export async function fetchPrice({ oracle, id }, withUnknownLogging = true): Promise<number> {
+export async function fetchPrice(
+  { oracle, id },
+  withUnknownLogging: boolean | string = true
+): Promise<number> {
   if ((oracle === 'lps' || oracle === 'tokens' || oracle === 'any') && typeof id === 'string') {
     return fetchPriceTyped({ oracle, id }, withUnknownLogging);
   }
@@ -42,7 +45,7 @@ export async function fetchPrice({ oracle, id }, withUnknownLogging = true): Pro
  */
 export async function fetchPriceTyped(
   { oracle, id }: FetchPriceParams,
-  withUnknownLogging = true
+  withUnknownLogging: boolean | string = true
 ): Promise<number> {
   if (oracle === undefined) {
     console.trace('Undefined oracle for fetchPrice, expected one of: lps, tokens, any, hardcode');
@@ -86,7 +89,7 @@ export async function fetchPriceTyped(
  */
 export async function fetchPriceFromOracleId(
   oracleId: string,
-  withUnknownLogging = true
+  withUnknownLogging: boolean | string = true
 ): Promise<number> {
   return fetchPriceTyped({ oracle: 'any', id: oracleId }, withUnknownLogging);
 }
@@ -96,7 +99,7 @@ export async function fetchPriceFromOracleId(
  */
 export async function fetchPriceFromToken(
   token: Token,
-  withUnknownLogging = true
+  withUnknownLogging: boolean | string = true
 ): Promise<number> {
   return fetchPriceFromOracleId(token.oracleId, withUnknownLogging);
 }
@@ -107,7 +110,7 @@ export async function fetchPriceFromToken(
 export async function fetchPriceFromTokenId(
   id: string,
   chainId: ChainId | keyof typeof ChainId,
-  withUnknownLogging = true
+  withUnknownLogging: boolean | string = true
 ): Promise<number> {
   const enumChainId: ChainId = typeof chainId === 'string' ? ChainId[chainId] : chainId;
   const token = addressBookByChainId[enumChainId].tokens[id];
@@ -123,7 +126,7 @@ export async function fetchPriceFromTokenId(
 export async function fetchPriceFromTokenAddress(
   address: string,
   chainId: ChainId | keyof typeof ChainId,
-  withUnknownLogging = true
+  withUnknownLogging: boolean | string = true
 ): Promise<number> {
   const enumChainId: ChainId = typeof chainId === 'string' ? ChainId[chainId] : chainId;
   const checksumAddress = getAddress(address);


### PR DESCRIPTION
2nd param to `fetchPrice` can now also be a `string`, which will be output rather than the default `Consider adding it to .json file.`
Helpful to find out why an error is occurring / decide if you want to turn off the missing logging (by passing false) 

example for updateMooTokenPrices:
```patch
- let price = await fetchPrice({ oracle: vault.oracle, id: vault.oracleId });
+ let price = await fetchPrice(
+  { oracle: vault.oracle, id: vault.oracleId },
+  `oracleId of ${vault.id} on ${vault.chain} in updateMooTokenPrices`
+ );
```

before:
```
Unknown oracleId 'equilibre-dai-usdc' in lps oracle. Consider adding it to .json file.
Unknown oracleId 'sushi-kava-usdt-wkava' in lps oracle. Consider adding it to .json file.
[...]
```

after:
```
Unknown oracleId 'equilibre-dai-usdc' in lps oracle. oracleId of equilibre-dai-usdc on kava in updateMooTokenPrices
Unknown oracleId 'sushi-kava-usdt-wkava' in lps oracle. oracleId of sushi-kava-usdt-wkava on kava in updateMooTokenPrices
Unknown oracleId 'blizz-blzz-avax' in lps oracle. oracleId of blizz-blzz-avax on avax in updateMooTokenPrices
Unknown oracleId 'joe-syn-wavax' in lps oracle. oracleId of joe-syn-wavax-eol on avax in updateMooTokenPrices
Unknown oracleId 'mdex-shib-usdt' in lps oracle. oracleId of mdex-shib-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-bifi-usdt' in lps oracle. oracleId of mdex-bifi-usdt on heco in updateMooTokenPrices
Unknown oracleId 'hfi-hfi-ht' in lps oracle. oracleId of hfi-hfi-ht-eol on heco in updateMooTokenPrices
Unknown oracleId 'hfi-hfi-husd' in lps oracle. oracleId of hfi-hfi-husd-eol on heco in updateMooTokenPrices
Unknown oracleId 'LAVA' in tokens oracle. oracleId of lava-lava-eol on heco in updateMooTokenPrices
Unknown oracleId 'lava-lava-usdt' in lps oracle. oracleId of lava-lava-usdt-eol on heco in updateMooTokenPrices
Unknown oracleId 'lava-lava-wht' in lps oracle. oracleId of lava-lava-wht-eol on heco in updateMooTokenPrices
Unknown oracleId 'mdex-husd-usdt' in lps oracle. oracleId of mdex-husd-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-hdot-usdt' in lps oracle. oracleId of mdex-hdot-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-hfil-usdt' in lps oracle. oracleId of mdex-hfil-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-hpt-usdt' in lps oracle. oracleId of mdex-hpt-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-aave-usdt' in lps oracle. oracleId of mdex-aave-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-snx-usdt' in lps oracle. oracleId of mdex-snx-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-link-usdt' in lps oracle. oracleId of mdex-link-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-bal-usdt' in lps oracle. oracleId of mdex-bal-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-yfi-usdt' in lps oracle. oracleId of mdex-yfi-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-mdx-usdt' in lps oracle. oracleId of mdex-mdx-usdt on heco in updateMooTokenPrices
Unknown oracleId 'mdex-mdx-wht' in lps oracle. oracleId of mdex-mdx-wht on heco in updateMooTokenPrices
Unknown oracleId 'mdex-wht-usdt' in lps oracle. oracleId of mdex-wht-usdt on heco in updateMooTokenPrices
Unknown oracleId 'lendhub-lhb-wht' in lps oracle. oracleId of lendhub-lhb-wht-eol on heco in updateMooTokenPrices
Unknown oracleId 'lendhub-lhb-usdt' in lps oracle. oracleId of lendhub-lhb-usdt-eol on heco in updateMooTokenPrices
Unknown oracleId 'MDX' in tokens oracle. oracleId of mdex-mdx-eol on heco in updateMooTokenPrices
Unknown oracleId 'mdex-hbtc-wht' in lps oracle. oracleId of mdex-hbtc-wht-eol on heco in updateMooTokenPrices
Unknown oracleId 'mdex-eth-wht' in lps oracle. oracleId of mdex-eth-wht-eol on heco in updateMooTokenPrices
Unknown oracleId 'mdex-hltc-usdt' in lps oracle. oracleId of mdex-hltc-usdt-eol on heco in updateMooTokenPrices
Unknown oracleId 'mdex-hbch-usdt' in lps oracle. oracleId of mdex-hbch-usdt-eol on heco in updateMooTokenPrices
Unknown oracleId 'mdex-lhb-usdt' in lps oracle. oracleId of mdex-lhb-usdt-eol on heco in updateMooTokenPrices
Unknown oracleId 'mdex-uni-usdt' in lps oracle. oracleId of mdex-uni-usdt-eol on heco in updateMooTokenPrices
Unknown oracleId 'mdex-hbtc-usdt' in lps oracle. oracleId of mdex-hbtc-usdt-eol on heco in updateMooTokenPrices
Unknown oracleId 'mdex-eth-usdt' in lps oracle. oracleId of mdex-eth-usdt-eol on heco in updateMooTokenPrices
Unknown oracleId 'MDX' in tokens oracle. oracleId of mdex-bsc-mdx on bsc in updateMooTokenPrices
Unknown oracleId 'dopple-dop-lp' in lps oracle. oracleId of dopple-dop-lp on bsc in updateMooTokenPrices
Unknown oracleId 'dopple-ust-lp' in lps oracle. oracleId of dopple-ust-lp on bsc in updateMooTokenPrices
Unknown oracleId 'dopple-dolly-lp' in lps oracle. oracleId of dopple-dolly-lp on bsc in updateMooTokenPrices
Unknown oracleId 'alpaca-ibalpaca' in lps oracle. oracleId of alpaca-ibalpaca-eol on bsc in updateMooTokenPrices
Unknown oracleId 'equalizer-ankr-ankrftm' in lps oracle. oracleId of equalizer-ankr-ankrftm on fantom in updateMooTokenPrices
Unknown oracleId 'spiritV2-usdc-busd' in lps oracle. oracleId of spiritV2-usdc-busd on fantom in updateMooTokenPrices
Unknown oracleId 'spiritV2-usdc-alusd' in lps oracle. oracleId of spiritV2-usdc-alusd on fantom in updateMooTokenPrices
Unknown oracleId 'solidly-wftm-solid' in lps oracle. oracleId of solidly-wftm-solid on fantom in updateMooTokenPrices
Unknown oracleId 'stakesteak-fusd-usdc' in lps oracle. oracleId of stakesteak-fusd-usdc-eol on fantom in updateMooTokenPrices
Unknown oracleId 'ironswap-iron' in lps oracle. oracleId of ironswap-iron on polygon in updateMooTokenPrices
Unknown oracleId 'ironswap-3usd' in lps oracle. oracleId of ironswap-3usd on polygon in updateMooTokenPrices
Unknown oracleId 'newQUICK' in tokens oracle. oracleId of quick-newquick on polygon in updateMooTokenPrices
```