### PR TITLE
Update: Show supplyApr for lending strats

### DIFF
--- a/src/api/stats/common/aave/getAaveV3Apys.js
+++ b/src/api/stats/common/aave/getAaveV3Apys.js
@@ -44,7 +44,9 @@ const getAaveV3ApyData = async (config, pools, chainId) => {
     Object.fromEntries(pools.map((p, i) => [p.name, lendingApys[i]])),
     rewardApys,
     0,
-    lsApys
+    lsApys,
+    [],
+    'supplyApr'
   );
 };
 

--- a/src/api/stats/common/getApyBreakdown.ts
+++ b/src/api/stats/common/getApyBreakdown.ts
@@ -16,6 +16,7 @@ export interface ApyBreakdown {
   totalApy?: number;
   liquidStakingApr?: number;
   composablePoolApr?: number;
+  supplyApr?: number;
 }
 
 export interface ApyBreakdownResult {
@@ -29,7 +30,8 @@ export const getApyBreakdown = (
   farmAprs: BigNumber[],
   providerFee?: number | BigNumber[],
   liquidStakingAprs?: number[],
-  composablePoolAprs?: number[]
+  composablePoolAprs?: number[],
+  mainLabel: 'tradingApr' | 'supplyApr' = 'tradingApr'
 ): ApyBreakdownResult => {
   const result: ApyBreakdownResult = {
     apys: {},
@@ -41,22 +43,11 @@ export const getApyBreakdown = (
   }
 
   pools.forEach((pool, i) => {
-    const liquidStakingApr: number | undefined = liquidStakingAprs
-      ? liquidStakingAprs[i]
-      : undefined;
+    const liquidStakingApr: number = liquidStakingAprs?.[i] || 0;
 
-    const composablePoolApr: number | undefined = composablePoolAprs
-      ? composablePoolAprs[i]
-      : undefined;
+    const composablePoolApr: number = composablePoolAprs?.[i] || 0;
 
-    const extraApr =
-      liquidStakingAprs && composablePoolAprs
-        ? liquidStakingApr + composablePoolApr
-        : liquidStakingAprs
-        ? liquidStakingApr
-        : composablePoolAprs
-        ? composablePoolApr
-        : 0;
+    const extraApr: number = liquidStakingApr + composablePoolApr;
 
     const provFee = providerFee[i] == undefined ? providerFee : providerFee[i].toNumber();
     const simpleApr = farmAprs[i]?.toNumber();
@@ -87,7 +78,7 @@ export const getApyBreakdown = (
       beefyPerformanceFee: beefyPerformanceFee,
       vaultApy: vaultApy,
       lpFee: provFee,
-      tradingApr: tradingApr,
+      [mainLabel]: tradingApr,
       liquidStakingApr: liquidStakingApr,
       composablePoolApr: composablePoolApr,
       totalApy: totalApy,

--- a/src/api/stats/common/getCompoundV2Apys.ts
+++ b/src/api/stats/common/getCompoundV2Apys.ts
@@ -53,7 +53,9 @@ const getCompoundV2ApyData = async (params: CompoundV2ApyParams) => {
     Object.fromEntries(params.pools.map((p, i) => [p.name, supplyApys[i]])),
     supplyCompApys,
     0,
-    liquidStakingApys
+    liquidStakingApys,
+    [],
+    'supplyApr'
   );
 };
 

--- a/src/api/stats/common/getSiloApys.ts
+++ b/src/api/stats/common/getSiloApys.ts
@@ -28,7 +28,9 @@ const getSiloApyData = async (params: SiloApyParams) => {
     Object.fromEntries(params.pools.map((p, i) => [p.name, supplyApys[i]])),
     supplySiloApys,
     0,
-    liquidStakingApys
+    liquidStakingApys,
+    [],
+    'supplyApr'
   );
 };
 

--- a/src/api/stats/common/hop/getHopCommonApys.js
+++ b/src/api/stats/common/hop/getHopCommonApys.js
@@ -14,7 +14,15 @@ export const getHopCommonApys = async params => {
     getLsAprs(params),
   ]);
 
-  return getApyBreakdown(params.pools, tradingAprs, farmApys, 0.0004, liquidStakingAprs);
+  return getApyBreakdown(
+    params.pools,
+    tradingAprs,
+    farmApys,
+    0.0004,
+    liquidStakingAprs,
+    [],
+    'supplyApr'
+  );
 };
 
 const getTradingAprs = async params => {

--- a/src/api/stats/getApys.js
+++ b/src/api/stats/getApys.js
@@ -25,7 +25,7 @@ const { fetchBoostAprs } = require('./getBoostAprs');
 
 const INIT_DELAY = process.env.INIT_DELAY || 30 * 1000;
 const BOOST_APR_INIT_DELAY = 30 * 1000;
-var REFRESH_INTERVAL = 15 * 60 * 1000;
+const REFRESH_INTERVAL = 15 * 60 * 1000;
 const BOOST_REFRESH_INTERVAL = 2 * 60 * 1000;
 
 let apys = {};
@@ -89,7 +89,7 @@ const updateApys = async () => {
       }
 
       // Break out to apy and breakdowns if possible
-      let hasApyBreakdowns = 'apyBreakdowns' in result.value;
+      const hasApyBreakdowns = 'apyBreakdowns' in result.value;
       if (hasApyBreakdowns) {
         mappedApyValues = result.value.apys;
         mappedApyBreakdownValues = result.value.apyBreakdowns;

--- a/src/api/stats/optimism/getExactlyApys.js
+++ b/src/api/stats/optimism/getExactlyApys.js
@@ -31,7 +31,9 @@ const getExactlyApys = async () => {
     Object.fromEntries(pools.map((p, i) => [p.name, lendingApys[i]])),
     rewardApys,
     0,
-    lsApys
+    lsApys,
+    [],
+    'supplyApr'
   );
 };
 


### PR DESCRIPTION
Return `supplyApr` instead `tradingApr` on `apy/breakdwon` for lending strats

eg : 
```json
[
"seamless-usdbc": {
"vaultApr": 0.19658461757583676,
"compoundingsPerYear": 2190,
"beefyPerformanceFee": 0.095,
"vaultApy": 0.21722757705799078,
"lpFee": 0,
"supplyApr": 0.00000543258275377198,
"liquidStakingApr": 0,
"composablePoolApr": 0,
"totalApy": 0.2172341897475334
}, //dev
"seamless-usdbc": {
"vaultApr": 0.19418793482588761,
"compoundingsPerYear": 2190,
"beefyPerformanceFee": 0.095,
"vaultApy": 0.2143140214899324,
"lpFee": 0,
"tradingApr": 0.00000543163620594223,
"liquidStakingApr": 0,
"totalApy": 0.21432061720193696
}//prod
] 
```