### PR TITLE
filter bad rpcs

### DIFF
--- a/src/api/rpc/rpcs.ts
+++ b/src/api/rpc/rpcs.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '../../../packages/address-book/address-book';
+import { mapValues, partition } from 'lodash';
 
 const rpcs: Record<ChainId, string[]> = {
   [ChainId.ethereum]: [
@@ -246,5 +247,150 @@ const rpcs: Record<ChainId, string[]> = {
     'https://1rpc.io/aurora',
   ],
 };
+
+export type ErrorRpcResponse = {
+  error: {
+    code: number;
+    message: string;
+  };
+  id: number;
+  jsonrpc: '2.0';
+};
+
+export type SuccessRpcResponse<TResult> = {
+  result: TResult;
+  id: number;
+  jsonrpc: '2.0';
+};
+
+export type RpcResponse<TResult> = ErrorRpcResponse | SuccessRpcResponse<TResult>;
+
+const LOG_ERRORS: boolean = false;
+const LOG_INFO: boolean = false;
+
+export async function initRpcs(): Promise<void> {
+  const counts = mapValues(rpcs, rpcs => rpcs.length);
+
+  await Promise.all(
+    Object.keys(rpcs).map(async key => {
+      const chainId = Number(key) as keyof typeof rpcs; // object keys are strings
+      const chainName = ChainId[chainId];
+      const endpoints = rpcs[chainId]!;
+      const blockNumbers = await Promise.all(
+        endpoints.map(async (rpc, i) => {
+          try {
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 3000);
+            const response = await fetch(rpc, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Origin: 'https://api.beefy.finance',
+              },
+              body: JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'eth_blockNumber',
+                params: [],
+                id: i,
+              }),
+              signal: controller.signal,
+            });
+            clearTimeout(timeout);
+
+            const json = (await response.json()) as RpcResponse<string>;
+            if ('error' in json) {
+              if (LOG_ERRORS) {
+                console.error('initRpcs::error', chainName, rpc, json);
+              }
+              return undefined;
+            }
+
+            return BigInt(json.result);
+          } catch (e) {
+            if (LOG_ERRORS) {
+              console.error('initRpcs::error', chainName, rpc, e);
+            }
+            return undefined;
+          }
+        })
+      );
+
+      const endpointsToRemove = new Set<string>();
+      const endpointsToCheck: { rpc: string; blockNumber: bigint }[] = [];
+
+      for (let i = 0; i < endpoints.length; i++) {
+        if (!blockNumbers[i]) {
+          if (LOG_INFO) {
+            console.log(
+              'initRpcs::info',
+              chainName,
+              'removing endpoint',
+              endpoints[i],
+              'no block number returned'
+            );
+          }
+          endpointsToRemove.add(endpoints[i]);
+        } else {
+          endpointsToCheck.push({ rpc: endpoints[i], blockNumber: blockNumbers[i] });
+        }
+      }
+
+      if (endpointsToCheck.length === 0) {
+        if (LOG_ERRORS) {
+          console.error(
+            'initRpcs::error',
+            chainName,
+            'no block numbers for chain',
+            'allowing all rpcs'
+          );
+        }
+        return;
+      }
+
+      // Allow +/- 2 blocks from the median block number
+      const sortedBlockNumbers = blockNumbers.filter(Boolean).sort((a, b) => Number(a - b));
+      const medianBlockNumber = sortedBlockNumbers[Math.floor(sortedBlockNumbers.length / 2)];
+      const minBlockNumber = medianBlockNumber - 2n;
+      const maxBlockNumber = medianBlockNumber + 2n;
+
+      for (const endpoint of endpointsToCheck) {
+        if (endpoint.blockNumber < minBlockNumber || endpoint.blockNumber > maxBlockNumber) {
+          endpointsToRemove.add(endpoint.rpc);
+          if (LOG_INFO) {
+            console.log(
+              'initRpcs::info',
+              chainId,
+              'removing endpoint',
+              endpoint.rpc,
+              'blockNumber',
+              endpoint.blockNumber,
+              'minBlockNumber',
+              minBlockNumber,
+              'maxBlockNumber',
+              maxBlockNumber
+            );
+          }
+        }
+      }
+
+      if (endpointsToRemove.size > 0) {
+        console.log('initRpcs', chainName, 'removing endpoints', Array.from(endpointsToRemove));
+        const validChains = rpcs[chainId].filter(rpc => !endpointsToRemove.has(rpc));
+        if (validChains.length) {
+          rpcs[chainId] = validChains;
+        } else {
+          if (LOG_ERRORS) {
+            console.error('initRpcs::error', chainName, 'no valid rpcs left, allowing all');
+          }
+        }
+      }
+    })
+  );
+
+  for (const key of Object.keys(rpcs)) {
+    const endpoints = rpcs[key]!;
+    console.log('initRpcs', ChainId[key], endpoints.length, '/', counts[key], 'endpoints');
+  }
+}
 
 export const getChainRpcs = (chainId: ChainId): string[] => rpcs[chainId] ?? [];

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@
 require('dotenv').config();
 
 import { initCache } from './utils/cache';
+import { initRpcs } from './api/rpc/rpcs';
 import { initBoostService } from './api/boosts/getBoosts';
 import { initPriceService } from './api/stats/getAmmPrices';
 import { initApyService } from './api/stats/getApys';
@@ -47,6 +48,7 @@ const port = process.env.PORT || 3000;
 
 const start = async () => {
   await initCache();
+  await initRpcs();
 
   initApyService();
   initPriceService();


### PR DESCRIPTION
Currently removing any rpc that:
- takes longer than 3 seconds to respond
- or, fails to respond with block number
- or, that block number is out with ±2 of the median of all block numbers returned for that chain

If these checks would remove all rpcs for a chain, then none are removed.

Not sure how viem fallback scores rpcs, maybe it was already doing something similar, but at least this will make it not have to keep checking bad ones. 

Example: https://base.llamarpc.com is stuck on block number 4966442 where as chain is on block number 8489749+

```
initRpcs::error ethereum https://eth-mainnet.nodereal.io/v1/1659dfb40aa24bbb8153a677b98064d7 {
  jsonrpc: '2.0',
  id: null,
  error: {
    code: -32005,
    message: 'You have reached the maximum API usage limit of public. If you need higher throughput, please check out https://meganode.nodereal.io/'
  }
}
initRpcs::info ethereum removing endpoint https://eth-mainnet.nodereal.io/v1/1659dfb40aa24bbb8153a677b98064d7 no block number returned
initRpcs ethereum removing endpoints [
  'https://eth-mainnet.nodereal.io/v1/1659dfb40aa24bbb8153a677b98064d7'
]
initRpcs::error optimism https://api.zan.top/node/v1/opt/mainnet/public {
  error: {
    code: -32002,
    message: 'auth check error; request origin required but not specified, requestOrigin: https://api.beefy.finance'
  },
  id: 10,
  jsonrpc: '2.0'
}
initRpcs::info optimism removing endpoint https://api.zan.top/node/v1/opt/mainnet/public no block number returned
initRpcs::info 10 removing endpoint https://optimism.llamarpc.com blockNumber 106273919n minBlockNumber 114085029n maxBlockNumber 114085033n
initRpcs optimism removing endpoints [
  'https://api.zan.top/node/v1/opt/mainnet/public',
  'https://optimism.llamarpc.com'
]
initRpcs::error bsc https://api.zan.top/node/v1/bsc/mainnet/public {
  error: {
    code: -32002,
    message: 'auth check error; request origin required but not specified, requestOrigin: https://api.beefy.finance'
  },
  id: 25,
  jsonrpc: '2.0'
}
initRpcs::info bsc removing endpoint https://api.zan.top/node/v1/bsc/mainnet/public no block number returned
initRpcs bsc removing endpoints [ 'https://api.zan.top/node/v1/bsc/mainnet/public' ]
initRpcs::info 1285 removing endpoint https://moonriver.publicnode.com blockNumber 92444200n minBlockNumber 5829626n maxBlockNumber 5829630n
initRpcs moonriver removing endpoints [ 'https://moonriver.publicnode.com' ]
initRpcs::info 25 removing endpoint https://cronos-evm.publicnode.com blockNumber 18308058n minBlockNumber 11817168n maxBlockNumber 11817172n
initRpcs cronos removing endpoints [ 'https://cronos-evm.publicnode.com' ]
initRpcs::error polygon https://api.zan.top/node/v1/polygon/mainnet/public {
  error: {
    code: -32002,
    message: 'auth check error; request origin required but not specified, requestOrigin: https://api.beefy.finance'
  },
  id: 12,
  jsonrpc: '2.0'
}
initRpcs::info polygon removing endpoint https://api.zan.top/node/v1/polygon/mainnet/public no block number returned
initRpcs::info 137 removing endpoint https://polygon.meowrpc.com blockNumber 51658922n minBlockNumber 51658924n maxBlockNumber 51658928n
initRpcs polygon removing endpoints [
  'https://api.zan.top/node/v1/polygon/mainnet/public',
  'https://polygon.meowrpc.com'
]
initRpcs::info 1284 removing endpoint https://moonbeam.publicnode.com blockNumber 85427320n minBlockNumber 5178476n maxBlockNumber 5178480n
initRpcs moonbeam removing endpoints [ 'https://moonbeam.publicnode.com' ]
initRpcs::info 1101 removing endpoint https://rpc.polygon-zkevm.gateway.fm blockNumber 8838635n minBlockNumber 8839085n maxBlockNumber 8839089n
initRpcs zkevm removing endpoints [ 'https://rpc.polygon-zkevm.gateway.fm' ]
initRpcs::info 42161 removing endpoint https://endpoints.omniatech.io/v1/arbitrum/one/public blockNumber 164616350n minBlockNumber 164616355n maxBlockNumber 164616359n
initRpcs::info 42161 removing endpoint https://arbitrum.meowrpc.com blockNumber 164616347n minBlockNumber 164616355n maxBlockNumber 164616359n
initRpcs arbitrum removing endpoints [
  'https://endpoints.omniatech.io/v1/arbitrum/one/public',
  'https://arbitrum.meowrpc.com'
]
initRpcs::info 8453 removing endpoint https://base.llamarpc.com blockNumber 4966442n minBlockNumber 8489745n maxBlockNumber 8489749n
initRpcs base removing endpoints [ 'https://base.llamarpc.com' ]
initRpcs::error avax https://api.zan.top/node/v1/avax/mainnet/public/ext/bc/C/rpc {
  error: {
    code: -32002,
    message: 'auth check error; request origin required but not specified, requestOrigin: https://api.beefy.finance'
  },
  id: 8,
  jsonrpc: '2.0'
}
initRpcs::info avax removing endpoint https://api.zan.top/node/v1/avax/mainnet/public/ext/bc/C/rpc no block number returned
initRpcs avax removing endpoints [ 'https://api.zan.top/node/v1/avax/mainnet/public/ext/bc/C/rpc' ]
initRpcs::error gnosis https://gnosis.drpc.org DOMException [AbortError]: This operation was aborted
initRpcs::info gnosis removing endpoint https://gnosis.drpc.org no block number returned
initRpcs::info 100 removing endpoint https://rpc.ankr.com/gnosis blockNumber 31668117n minBlockNumber 31668118n maxBlockNumber 31668122n
initRpcs::info 100 removing endpoint https://endpoints.omniatech.io/v1/gnosis/mainnet/public blockNumber 31668117n minBlockNumber 31668118n maxBlockNumber 31668122n
initRpcs gnosis removing endpoints [
  'https://gnosis.drpc.org',
  'https://rpc.ankr.com/gnosis',
  'https://endpoints.omniatech.io/v1/gnosis/mainnet/public'
]
initRpcs::error zksync https://zksync.drpc.org DOMException [AbortError]: This operation was aborted
initRpcs::error zksync https://zksync.meowrpc.com DOMException [AbortError]: This operation was aborted
initRpcs::info zksync removing endpoint https://zksync.drpc.org no block number returned
initRpcs::info zksync removing endpoint https://zksync.meowrpc.com no block number returned
initRpcs zksync removing endpoints [ 'https://zksync.drpc.org', 'https://zksync.meowrpc.com' ]
initRpcs::error kava https://kava.api.onfinality.io/public DOMException [AbortError]: This operation was aborted
initRpcs::info kava removing endpoint https://kava.api.onfinality.io/public no block number returned
initRpcs kava removing endpoints [ 'https://kava.api.onfinality.io/public' ]
initRpcs::error aurora https://1rpc.io/aurora DOMException [AbortError]: This operation was aborted
initRpcs::info aurora removing endpoint https://1rpc.io/aurora no block number returned
initRpcs aurora removing endpoints [ 'https://1rpc.io/aurora' ]
initRpcs ethereum 24 / 25 endpoints
initRpcs cronos 3 / 4 endpoints
initRpcs bsc 25 / 26 endpoints
initRpcs gnosis 8 / 11 endpoints
initRpcs fuse 4 / 4 endpoints
initRpcs heco 2 / 2 endpoints
initRpcs polygon 14 / 16 endpoints
initRpcs fantom 10 / 10 endpoints
initRpcs metis 3 / 3 endpoints
initRpcs zkevm 6 / 7 endpoints
initRpcs moonbeam 6 / 7 endpoints
initRpcs moonriver 4 / 5 endpoints
initRpcs kava 3 / 4 endpoints
initRpcs canto 4 / 4 endpoints
initRpcs base 12 / 13 endpoints
initRpcs arbitrum 8 / 10 endpoints
initRpcs celo 4 / 4 endpoints
initRpcs emerald 2 / 2 endpoints
initRpcs linea 4 / 4 endpoints
initRpcs aurora 2 / 3 endpoints
initRpcs one 6 / 6 endpoints
```