### PR TITLE
Add Base axlOP Token Reward

### DIFF
--- a/packages/address-book/address-book/base/tokens/tokens.ts
+++ b/packages/address-book/address-book/base/tokens/tokens.ts
@@ -596,12 +596,25 @@ const _tokens = {
     chainId: 8453,
     decimals: 18,
     logoURI: '',
-    website:
-      'https://basegod.fun/',
+    website: 'https://basegod.fun/',
     description:
       'In the spirit of being based and fair, $TYBG was stealth launched with no tax or team/presale tokens. Memecoin.',
     documentation: '',
     bridge: 'native',
+  },
+  axlOP: {
+    name: 'Axelar Wrapped OP',
+    symbol: 'axlOP',
+    oracleId: 'axlOP',
+    address: '0x994ac01750047B9d35431a7Ae4Ed312ee955E030',
+    chainId: 8453,
+    decimals: 18,
+    logoURI: '',
+    website: 'https://app.optimism.io/governance',
+    description:
+      'Optimistic Rollup is a layer 2 scaling solution that scales both transaction throughput and computation on Ethereum. The backbone of our implementation is the Optimistic Virtual Machine (OVM), which is fully compatible with the EVM.',
+    documentation: '',
+    bridge: 'axelar',
   },
 } as const;
 

--- a/src/data/base/aerodromeLpPools.json
+++ b/src/data/base/aerodromeLpPools.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "aerodrome-weth-axlop",
+    "address": "0x6a071315B5Ae7da81CA56901ff13893F84776c7B",
+    "gauge": "0xf2B43787C9F841B69567Df52DD6669F4D6De293f",
+    "decimals": "1e18",
+    "chainId": 8453,
+    "beefyFee": 0.095,
+    "lp0": {
+      "address": "0x4200000000000000000000000000000000000006",
+      "oracle": "tokens",
+      "oracleId": "WETH",
+      "decimals": "1e18"
+    },
+    "lp1": {
+      "address": "0x994ac01750047B9d35431a7Ae4Ed312ee955E030",
+      "oracle": "tokens",
+      "oracleId": "axlOP",
+      "decimals": "1e18"
+    }
+  },
+  {
     "name": "aerodrome-tybg-weth",
     "address": "0x20000FbfeDFD172821821C9c59284129B04ffB2e",
     "gauge": "0xa1D8F6a8EC2236A9919eB7E990Bb27791C139a37",

--- a/src/data/base/bvmLpPools.json
+++ b/src/data/base/bvmLpPools.json
@@ -111,6 +111,11 @@
         "address": "0x4200000000000000000000000000000000000006",
         "oracleId": "WETH",
         "decimals": "1e18"
+      },
+      {
+        "address": "0x994ac01750047B9d35431a7Ae4Ed312ee955E030",
+        "oracleId": "axlOP",
+        "decimals": "1e18"
       }
     ],
     "lp0": {


### PR DESCRIPTION
Uses `aerodrome-weth-axlop` to get price of axlOP on Base chain, then adds the token to calculation of `bvm-weth-bvm` rewards.