### PR TITLE
add arb rewards

### DIFF
--- a/src/data/arbitrum/auraLpPools.json
+++ b/src/data/arbitrum/auraLpPools.json
@@ -135,6 +135,11 @@
         "rewardGauge": "0x4b751A9364BadFed9f2B8BC7EAd89fbc7214DbF6",
         "oracleId": "AURA",
         "decimals": "1e18"
+      },
+      {
+        "rewardGauge": "0x6c48421328Ba4ef61FA0DBFfb7433E5BC1d7fa52",
+        "oracleId": "ARB",
+        "decimals": "1e18"
       }
     ],
     "tokens": [
@@ -218,6 +223,11 @@
       {
         "rewardGauge": "0x00C9437880B31318b277D7b2ef8CAaA08775c25d",
         "oracleId": "AURA",
+        "decimals": "1e18"
+      },
+      {
+        "rewardGauge": "0x3b5e4F8e1DD00fA4FC6edd4f568D971Fa01ccC02",
+        "oracleId": "ARB",
         "decimals": "1e18"
       }
     ],

--- a/src/data/arbitrum/auraLpPools.json
+++ b/src/data/arbitrum/auraLpPools.json
@@ -187,6 +187,11 @@
         "rewardGauge": "0x87c5f97a1Dd299a0DFcFc22E2dD3128707652e69",
         "oracleId": "USDC",
         "decimals": "1e6"
+      },
+      {
+        "rewardGauge": "0xA73Ad7230a759279f0542D7c5d1bDFD12E2195A9",
+        "oracleId": "ARB",
+        "decimals": "1e18"
       }
     ],
     "tokens": [


### PR DESCRIPTION
the strats:

[wstETH-​ETHx](https://arbiscan.io/address/0x5Ce77e3f0BeB4CBa42E01555B610a3E4e675827E)
[ezETH-​wstETH](https://arbiscan.io/address/0xFbAd355153d00504bb91605ed77a0871dD32F0e1)
[Gyroscope Aave USDC/​USDT](https://arbiscan.io/address/0xc18C87294b6F77D54E58E1C21545bdec7d820DE5)

accumulated a bit of arb already

could use this route:
`ethers.utils.solidityPack(["address", "uint24", "address"], [ARB, 500, ETH])`