### PR TITLE
change curve mai-usdc.e reward token

### DIFF
--- a/src/data/matic/curvePools.json
+++ b/src/data/matic/curvePools.json
@@ -5,8 +5,8 @@
     "gauge": "0x41cb0cb61c11039459dc81db76bd64d3ede704f2",
     "rewards": [
       {
-        "token": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
-        "oracleId": "WMATIC"
+        "token": "0xa3Fa99A148fA48D14Ed51d610c367C61876997F1",
+        "oracleId": "pMAI"
       }
     ],
     "tokens": [


### PR DESCRIPTION
theres no tonative route for MAI 0xa3Fa99A148fA48D14Ed51d610c367C61876997F1 on the swapper 0x28C7c59CFF2861eA6F1bEa19Fb03d0c7Fb315724 yet. 

most liq is here: 0x160532D2536175d65C03B97b0630A9802c274daD so could swap via quickswap.router (v2) and this 0x6e7a5FAFcec6BB1e78bAE2A1F0B612012BF14827 to WMATIC.

[pMAI, pUSDCe, WMATIC]