### PR TITLE
fetch dusd and remove timelock warning

### DIFF
--- a/packages/address-book/src/address-book/linea/tokens/tokens.ts
+++ b/packages/address-book/src/address-book/linea/tokens/tokens.ts
@@ -160,7 +160,6 @@ export const tokens = {
       'The Davos Protocol is an innovative collateralised debt position (CDP) protocol designed to facilitate the seamless minting of DUSD, an inflation-proof omnichain stablecoin, by leveraging Liquid Staking Tokens (LSTs). The protocol aims to address the challenges faced by traditional CDPs in decentralised finance (DeFi) by incorporating an unbiased monetary policy and fair borrowing rates, thereby enhancing user protection and promoting broader DeFi adoption. ',
     documentation: 'https://davos.xyz/assets/davos_whitepaper.pdf',
     bridge: 'native',
-    risks: ['NO_TIMELOCK'],
   },
   'USD+': {
     name: 'USD+',

--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -635,6 +635,7 @@ const coinGeckoCoins: Record<string, string[]> = {
   'ether-fi': ['ETHFI'],
   'anzen-usdz': ['USDz'],
   chompcoin: ['CHOMP'],
+  'davos-protocol': ['DUSD'],
 };
 
 /**


### PR DESCRIPTION
this multisig: 0x8F0E864AE6aD45d973BD5B3159D5a7079A83B774 is not a ward anymore; its this timelock with 2 hours minDelay: https://lineascan.build/address/0xdB24c61016c95531CD5F37aabA2d2133A4dF3c37#readContract now.

vault pr: https://github.com/beefyfinance/beefy-v2/pull/2121