### PR TITLE
add active curve lending markets with rewards

### DIFF
--- a/src/data/arbitrum/curveLendPools.json
+++ b/src/data/arbitrum/curveLendPools.json
@@ -1,1 +1,62 @@
-[]
+[
+    {
+        "name": "curve-lend-arb-weth-crvusd",
+        "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
+        "gauge": "0xbe543fc11b6eb4ae1a80cb4e06828f06dc3791da",
+        "oracleId": "crvUSD",
+        "rewards": [
+            {
+                "token": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+                "oracleId": "ARB"
+            }
+        ]
+    },
+    {
+        "name": "curve-lend-arb-wbtc-crvusd",
+        "address": "0xe07f1151887b8fdc6800f737252f6b91b46b5865",
+        "gauge": "0x46cc987dcd1d4d84ea5ecb2ce081ac4913b7c305",
+        "oracleId": "crvUSD",
+        "rewards": [
+            {
+                "token": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+                "oracleId": "ARB"
+            }
+        ]
+    },
+    {
+        "name": "curve-lend-arb-dlcbtc-crvusd",
+        "address": "0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d",
+        "gauge": "0x2656b01a19a790f07e2b875d69007f88241602f0",
+        "oracleId": "crvUSD",
+        "rewards": [
+            {
+                "token": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+                "oracleId": "ARB"
+            }
+        ]
+    },
+    {
+        "name": "curve-lend-arb-arb-crvusd",
+        "address": "0xa6c2e6a83d594e862cdb349396856f7ffe9a979b",
+        "gauge": "0x8d1600015ae09eaacaed08531a03ecb8f2bd40fa",
+        "oracleId": "crvUSD",
+        "rewards": [
+            {
+                "token": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+                "oracleId": "ARB"
+            }
+        ]
+    },
+    {
+        "name": "curve-lend-arb-asdCRV-crvusd",
+        "address": "0xc8248953429d707c6a2815653eca89846ffaa63b",
+        "gauge": "0x9f051b4aed6d675e9117cd1a2e6694d59f5d0492",
+        "oracleId": "crvUSD",
+        "rewards": [
+            {
+                "token": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
+                "oracleId": "CRV"
+            }
+        ]
+    }
+]


### PR DESCRIPTION


These are the markets currently having rewards. They will have rewards weeks to come (I manage that)

WETH/crvUSD: https://lend.curve.fi/#/arbitrum/markets/one-way-market-9/vault/deposit
Reward Token: ARB

WBTC/crvUSD: https://lend.curve.fi/#/arbitrum/markets/one-way-market-10/vault/deposit
Reward Token: ARB

dlcBTC/crvUSD: https://lend.curve.fi/#/arbitrum/markets/one-way-market-15/vault/deposit
Reward Token: ARB

ARB/crvUSD: https://lend.curve.fi/#/arbitrum/markets/one-way-market-11/vault/deposit
Reward Token: ARB

ARB/asdCRV: https://lend.curve.fi/#/arbitrum/markets/one-way-market-15/vault/deposit
Reward Token: CRV

These are all other markets that before. I reused the names. If the names have to be unique, I can change that.

If you hoover over the [i], you see the additional rewards on these markets

https://lend.curve.fi/#/arbitrum/markets?type=supply&sortBy=totalApr

As I blueprint I used infor from here: https://github.com/beefyfinance/beefy-api/blob/b44c00eff0aada0777bdee50a8634227c6ae2ca7/src/data/arbitrum/curveLendPools.json