### PR TITLE
Update/ remove HAY from bsc ab, replace HAY oracle for lisUSD

### DIFF
--- a/packages/address-book/src/address-book/bsc/tokens/tokens.ts
+++ b/packages/address-book/src/address-book/bsc/tokens/tokens.ts
@@ -230,20 +230,6 @@ export const tokens = {
     description:
       'HOOP is the reward and in-game currency for the Chibi Dinos Gaming Universe. It can be used to pay for merchandise and events; future uses include staking and governance for in-game decisions. Chibi Dinos is a basketball and dinosaur themed metaverse with games such as Primal Hoop, an arcade basketball game with an adventure role-playing game (RPG) mode and Primal Pickem, a predictive play-to earn game (P2E).',
   },
-  HAY: {
-    name: 'Hay Stablecoin',
-    symbol: 'HAY',
-    oracleId: 'HAY',
-    address: '0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5',
-    chainId: 56,
-    decimals: 18,
-    logoURI:
-      'https://tokens.pancakeswap.finance/images/0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5.svg',
-    website: 'https://helio.money/',
-    description:
-      'HAY is an over-collateralized destablecoin, where 1 HAY is always redeemable at $1 of cryptocurrency, and over-collateralized by BNB. Users can mint and borrow HAY by providing BNB as collateral, which can then be used to stake for yield, liquidity mining and as a means to transfer value.',
-    bridge: 'native',
-  },
   jCHF: {
     name: 'Jarvis Synthetic Swiss Franc',
     symbol: 'jCHF',

--- a/src/data/archive/oldLpPools.json
+++ b/src/data/archive/oldLpPools.json
@@ -537,7 +537,7 @@
     "lp0": {
       "address": "0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5",
       "oracle": "tokens",
-      "oracleId": "HAY",
+      "oracleId": "lisUSD",
       "decimals": "1e18"
     },
     "lp1": {

--- a/src/data/bsc/thenaLpPools.json
+++ b/src/data/bsc/thenaLpPools.json
@@ -29,7 +29,7 @@
     "lp0": {
       "address": "0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5",
       "oracle": "tokens",
-      "oracleId": "HAY",
+      "oracleId": "lisUSD",
       "decimals": "1e18"
     },
     "lp1": {
@@ -269,7 +269,7 @@
     "lp0": {
       "address": "0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5",
       "oracle": "tokens",
-      "oracleId": "HAY",
+      "oracleId": "lisUSD",
       "decimals": "1e18"
     },
     "lp1": {

--- a/src/data/bsc/thenaStableLpPools.json
+++ b/src/data/bsc/thenaStableLpPools.json
@@ -209,7 +209,7 @@
     "lp0": {
       "address": "0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5",
       "oracle": "tokens",
-      "oracleId": "HAY",
+      "oracleId": "lisUSD",
       "decimals": "1e18"
     },
     "lp1": {


### PR DESCRIPTION
`HAY` was migrated to `lisUSD` so don't need to have same token with two different names 