### PR TITLE
patch merkl apr calc

### DIFF
--- a/src/api/offchain-rewards/providers/merkl/types.ts
+++ b/src/api/offchain-rewards/providers/merkl/types.ts
@@ -10,6 +10,7 @@ type MerklApiForwarder = {
   target: string;
   owner: string;
   type: number;
+  label: string;
 };
 
 type MerklApiCampaignParameters = {
@@ -29,6 +30,8 @@ export type MerklApiCampaign = {
   mainParameter: string;
   forwarders: MerklApiForwarder[];
   campaignParameters: MerklApiCampaignParameters;
+  /** e.g. { "Beefy 0xDbaF4a5Ad4352adCDD2E914C1B1515E6F7451A82": 6.0934309620835405 } */
+  aprs: { [label: string]: number };
 };
 
 export type MerklApiCampaignsResponse = {

--- a/src/api/stats/arbitrum/getMerklGammaApys.js
+++ b/src/api/stats/arbitrum/getMerklGammaApys.js
@@ -1,40 +1,17 @@
+import { getApyBreakdown } from '../common/getApyBreakdown';
+import { ChainId } from '../../../../packages/address-book/src/types/chainid';
+import { getMerklAprs } from '../common/getMerklAprs';
+
 const BigNumber = require('bignumber.js');
 const uniPools = require('../../../data/arbitrum/uniswapGammaPools.json');
 const sushiPools = require('../../../data/arbitrum/sushiGammaPools.json');
-const { ARBITRUM_CHAIN_ID: chainId } = require('../../../constants');
-import { getApyBreakdown } from '../common/getApyBreakdown';
 
-const merklApi = 'https://api.angle.money/v2/merkl?chainIds=42161';
 const gammaApi = 'https://wire2.gamma.xyz/arbitrum/hypervisors/allData';
 const sushiGammaApi = 'https://wire2.gamma.xyz/sushi/arbitrum/hypervisors/allData';
 
 const pools = [...uniPools, ...sushiPools];
 const getMerklGammaApys = async () => {
-  let poolAprs = {};
-  try {
-    poolAprs = await fetch(merklApi).then(res => res.json());
-  } catch (e) {
-    console.error(`Failed to fetch Merkl APRs: ${chainId}`);
-  }
-
-  let aprs = [];
-  for (let i = 0; i < pools.length; ++i) {
-    let apr = BigNumber(0);
-    let merklPools = poolAprs[chainId].pools;
-    if (Object.keys(merklPools).length !== 0) {
-      for (const [key, value] of Object.entries(merklPools)) {
-        if (key.toLowerCase() === pools[i].pool.toLowerCase()) {
-          for (const [k, v] of Object.entries(value.alm)) {
-            if (k.toLowerCase() === pools[i].address.toLowerCase()) {
-              apr = BigNumber(v.almAPR).dividedBy(100);
-            }
-          }
-        }
-      }
-    }
-
-    aprs.push(apr);
-  }
+  const merklAprs = await getMerklAprs(ChainId.arbitrum, pools);
 
   let tradingAprs = {};
   try {
@@ -53,7 +30,7 @@ const getMerklGammaApys = async () => {
     console.log('Gamma Api Error', e);
   }
 
-  return await getApyBreakdown(pools, tradingAprs, aprs, 0);
+  return await getApyBreakdown(pools, tradingAprs, merklAprs, 0);
 };
 
 module.exports = getMerklGammaApys;

--- a/src/api/stats/base/getMerklBaseApys.js
+++ b/src/api/stats/base/getMerklBaseApys.js
@@ -1,38 +1,15 @@
+import { getMerklAprs } from '../common/getMerklAprs';
+import { getApyBreakdown } from '../common/getApyBreakdown';
+import { ChainId } from '../../../../packages/address-book/src/types/chainid';
+
 const BigNumber = require('bignumber.js');
 const sushiPools = require('../../../data/base/sushiGammaPools.json');
-const { BASE_CHAIN_ID: chainId } = require('../../../constants');
-import { getApyBreakdown } from '../common/getApyBreakdown';
 
-const merklApi = 'https://api.angle.money/v2/merkl?chainIds=8453';
 const gammaApi = 'https://wire2.gamma.xyz/sushi/base/hypervisors/allData';
 
 const pools = [...sushiPools];
 const getBaseMerklGammaApys = async () => {
-  let poolAprs = {};
-  try {
-    poolAprs = await fetch(merklApi).then(res => res.json());
-  } catch (e) {
-    console.error(`Failed to fetch Merkl APRs: ${chainId}`);
-  }
-
-  let aprs = [];
-  for (let i = 0; i < pools.length; ++i) {
-    let apr = BigNumber(0);
-    let merklPools = poolAprs[chainId].pools;
-    if (Object.keys(merklPools).length !== 0) {
-      for (const [key, value] of Object.entries(merklPools)) {
-        if (key.toLowerCase() === pools[i].pool.toLowerCase()) {
-          for (const [k, v] of Object.entries(value.alm)) {
-            if (k.toLowerCase() === pools[i].address.toLowerCase()) {
-              apr = BigNumber(v.almAPR).dividedBy(100);
-            }
-          }
-        }
-      }
-    }
-
-    aprs.push(apr);
-  }
+  const merklAprs = await getMerklAprs(ChainId.base, pools);
 
   let tradingAprs = {};
   try {
@@ -47,7 +24,7 @@ const getBaseMerklGammaApys = async () => {
     console.log('Gamma Base Api Error', e);
   }
 
-  return await getApyBreakdown(pools, tradingAprs, aprs, 0);
+  return await getApyBreakdown(pools, tradingAprs, merklAprs, 0);
 };
 
 module.exports = getBaseMerklGammaApys;

--- a/src/api/stats/common/getMerklAprs.ts
+++ b/src/api/stats/common/getMerklAprs.ts
@@ -1,0 +1,91 @@
+import { ChainId } from '../../../../packages/address-book/src/types/chainid';
+import BigNumber from 'bignumber.js';
+import { getJson } from '../../../utils/http';
+import { MerklApiCampaignsResponse } from '../../offchain-rewards/providers/merkl/types';
+import { BIG_ZERO } from '../../../utils/big-number';
+import { mapKeys } from 'lodash';
+import { isFiniteNumber } from '../../../utils/number';
+
+type MerklPoolRequest = {
+  /** address of ALM contract */
+  address: string;
+  /** address of pool (mainParameter) */
+  pool: string;
+};
+
+export enum MerklPoolType {
+  ERC20 = 1,
+  ConcentratedLiquidity,
+  ERC20Snapshot,
+  Airdrops,
+  Silo,
+  RadiantEmissions,
+  Morpho,
+  Dolomite,
+}
+
+export async function getMerklAprs(
+  chainId: ChainId,
+  pools: MerklPoolRequest[],
+  types: MerklPoolType[] = [MerklPoolType.ConcentratedLiquidity]
+): Promise<BigNumber[]> {
+  const aprs = pools.map(() => BIG_ZERO);
+
+  try {
+    const params = new URLSearchParams({
+      chainIds: chainId.toString(),
+      live: 'true',
+    });
+    for (const type of types) {
+      params.append('types', type.toString());
+    }
+
+    const data = await getJson<MerklApiCampaignsResponse>({
+      url: 'https://api.merkl.xyz/v3/campaigns',
+      params,
+    });
+
+    if (!data || typeof data !== 'object') {
+      throw new Error(`response error`);
+    }
+
+    if (Object.keys(data).length === 0) {
+      throw new Error(`no data returned`);
+    }
+
+    const dataForChain = data[chainId];
+    if (!dataForChain) {
+      throw new Error(`no data for chain returned`);
+    }
+
+    for (const poolCampaigns of Object.values(dataForChain)) {
+      for (const campaign of Object.values(poolCampaigns)) {
+        for (let i = 0; i < pools.length; ++i) {
+          const pool = pools[i];
+          if (pool.pool.toLowerCase() !== campaign.mainParameter.toLowerCase()) {
+            continue;
+          }
+
+          const poolForwarders = campaign.forwarders.filter(
+            forwarder => pool.address.toLowerCase() === forwarder.almAddress.toLowerCase()
+          );
+          if (poolForwarders.length === 0) {
+            continue;
+          }
+
+          const aprByLabel = mapKeys(campaign.aprs, (_, key) => key.toLowerCase());
+          for (const forwarder of poolForwarders) {
+            const apr = aprByLabel[forwarder.label.toLowerCase()];
+            if (apr && isFiniteNumber(apr)) {
+              aprs[i] = aprs[i].plus(apr / 100);
+            }
+          }
+        }
+      }
+    }
+  } catch (err: unknown) {
+    console.error(`getMerklAprs(${chainId}):`, err);
+  }
+
+  return aprs;
+}

--- a/src/data/optimism/uniswapGammaLpPools.json
+++ b/src/data/optimism/uniswapGammaLpPools.json
@@ -2,6 +2,7 @@
   {
     "name": "uniswap-gamma-weth-op-narrow",
     "address": "0xbcFa4cfA97f74a6AbF80b9901569BBc8654F4315",
+    "pool": "0x68F5C0A2DE713a54991E01858Fd27a3832401849",
     "decimals": "1e18",
     "beefyFee": 0.095,
     "poolId": 37,
@@ -22,6 +23,7 @@
   {
     "name": "uniswap-gamma-weth-op-wide",
     "address": "0x8480199E5D711399ABB4D51bDa329E064c89ad77",
+    "pool": "0x68F5C0A2DE713a54991E01858Fd27a3832401849",
     "decimals": "1e18",
     "beefyFee": 0.095,
     "poolId": 38,


### PR DESCRIPTION
Each forwarder under `campaign.forwarders` has an `almApr` field, however it is currently returning the same `almApr` for every campaign targeting the same pool (even when the campaign is inactive).

This patches the calc to look at the `aprs` map instead.