### PR TITLE
Fraxtal North Star changes

### DIFF
--- a/packages/address-book/src/address-book/ethereum/tokens/tokens.ts
+++ b/packages/address-book/src/address-book/ethereum/tokens/tokens.ts
@@ -196,16 +196,30 @@ export const tokens = {
   },
   FRAX: {
     chainId: 1,
-    address: '0x853d955aCEf822Db058eb8505911ED77F175b99e',
+    address: '0x853d955aCEf822Db058eb8505911ED77F175b99e', // LFRAX, convertable to frxUSD
     decimals: 18,
-    name: 'Frax',
-    symbol: 'FRAX',
+    name: 'Frax', // onchain: "Frax", offchain: "Legacy Frax Dollar"
+    symbol: 'FRAX', // onchain: "FRAX", offchain: "LFRAX"
     oracleId: 'FRAX',
     website: 'https://frax.finance/',
-    description: 'Frax is the first fractional-algorithmic stablecoin protocol.',
+    description:
+      'FRAX (LFRAX, Legacy Frax) is the original stablecoin of the Frax protocol. Users can migrate 1:1 to frxUSD.',
     bridge: 'native',
-    logoURI:
-      'https://raw.githubusercontent.com/pangolindex/tokens/main/assets/0xD24C2Ad096400B6FBcd2ad8B24E7acBc21A1da64/logo.png',
+    logoURI: '',
+    documentation: 'https://docs.frax.finance/',
+  },
+  frxUSD: {
+    chainId: 1,
+    address: '0xCAcd6fd266aF91b8AeD52aCCc382b4e165586E29', // new
+    decimals: 18,
+    name: 'Frax USD',
+    symbol: 'frxUSD',
+    oracleId: 'frxUSD', // TODO could be "FRAX" since it should be 1:1?
+    website: 'https://frax.finance/',
+    description:
+      'frxUSD is a replacement for FRAX on Ethereum. frxUSD is a crypto collateralized stablecoin pegged to the US dollar.',
+    bridge: 'native',
+    logoURI: '',
     documentation: 'https://docs.frax.finance/',
   },
   WBTC: {
@@ -1343,16 +1357,16 @@ export const tokens = {
     documentation: 'https://docs-new.staderlabs.com/intro',
   },
   FXS: {
-    name: 'Frax Share',
-    symbol: 'FXS',
+    name: 'Frax Share', // onchain: "Frax Share", offchain: "Frax"
+    symbol: 'FXS', // onchain: "FXS", offchain: "FRAX"
     oracleId: 'FXS',
-    address: '0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0',
+    address: '0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0', // now FRAX on Fraxtal
     chainId: 1,
     decimals: 18,
     logoURI: '',
     website: 'https://frax.finance/',
     description:
-      'The Frax Protocol introduced the world to the concept of a cryptocurrency being partially backed by collateral and partially stabilized algorithmically.',
+      'FRAX (previously FXS) is the governance token of the Frax Finance protocol and the gas token of the Fraxtal chain.',
     bridge: 'native',
   },
   wBETH: {

--- a/packages/address-book/src/address-book/fraxtal/tokens/tokens.ts
+++ b/packages/address-book/src/address-book/fraxtal/tokens/tokens.ts
@@ -1,10 +1,25 @@
 import type { Token } from '../../../types/token.js';
 
+const FXS = {
+  name: 'Wrapped Frax', // previously "Frax Share"
+  symbol: 'wFRAX', // previously "FXS"
+  oracleId: 'FXS', // keep the same so we don't lose historical data
+  address: '0xFc00000000000000000000000000000000000002',
+  chainId: 252,
+  decimals: 18,
+  website: 'https://frax.finance/',
+  bridge: 'native', // previously "fraxtal-canonical" (no longer OptimismMintableERC20, it is like WETH now)
+  description:
+    'FRAX (previously FXS) is the governance token of the Frax Finance protocol and the gas token of the Fraxtal chain.',
+  logoURI: 'https://app.sushi.com/images/tokens/fxs-square.jpg',
+  documentation: 'https://docs.frax.finance/',
+};
+
 const frxETH = {
-  name: 'Frax Wrapped Ether',
+  name: 'Frax Ether', // previously "Frax Wrapped Ether"
   address: '0xFC00000000000000000000000000000000000006',
-  symbol: 'wfrxETH',
-  oracleId: 'wfrxETH',
+  symbol: 'frxETH', // previously "wfrxETH"
+  oracleId: 'frxETH', // previously "wfrxETH" here (but both existed)
   decimals: 18,
   chainId: 252,
   website: 'https://app.frax.finance/frxeth/mint/',
@@ -16,9 +31,25 @@ const frxETH = {
 } as const satisfies Token;
 
 export const tokens = {
+  FXS, // now FRAX
+  WFXS: FXS, // now wFRAX
+  WNATIVE: FXS, // now wFRAX, previously wfrxETH
+  FRAX: {
+    chainId: 252,
+    address: '0xFc00000000000000000000000000000000000001',
+    decimals: 18,
+    name: 'Frax USD', // previously "Frax Dollar"
+    symbol: 'frxUSD', // previously "FRAX",
+    oracleId: 'FRAX', // keep the same so we don't lose historical data
+    website: 'https://frax.finance/',
+    description:
+      'frxUSD (previously FRAX) is a crypto collateralized stablecoin pegged to the US dollar',
+    bridge: 'fraxtal-canonical',
+    logoURI: '',
+    documentation: 'https://docs.frax.finance/',
+  },
   frxETH,
   wfrxETH: frxETH,
-  WNATIVE: frxETH,
   sfrxETH: {
     name: 'Staked Frax Ether',
     symbol: 'sfrxETH',
@@ -32,19 +63,6 @@ export const tokens = {
     bridge: 'fraxtal-canonical',
     logoURI: '',
     documentation: 'https://docs.frax.finance/frax-ether/frxeth-and-sfrxeth',
-  },
-  FRAX: {
-    chainId: 252,
-    address: '0xFc00000000000000000000000000000000000001',
-    decimals: 18,
-    name: 'Frax USD',
-    symbol: 'frxUSD',
-    oracleId: 'FRAX',
-    website: 'https://frax.finance/',
-    description: 'Frax is the first fractional-algorithmic stablecoin protocol.',
-    bridge: 'fraxtal-canonical',
-    logoURI: '',
-    documentation: 'https://docs.frax.finance/',
   },
   CRV: {
     name: 'CRV',
@@ -86,20 +104,6 @@ export const tokens = {
     chainId: 252,
     logoURI: 'https://ftmscan.com/token/images/USDC_32.png',
     documentation: 'https://developers.circle.com/docs',
-  },
-  FXS: {
-    name: 'Frax Share',
-    symbol: 'FXS',
-    oracleId: 'FXS',
-    address: '0xFc00000000000000000000000000000000000002',
-    chainId: 252,
-    decimals: 18,
-    website: 'https://frax.finance/',
-    bridge: 'fraxtal-canonical',
-    description:
-      'The Frax Share token (FXS) is the non-stable, utility token in the protocol. It is meant to be volatile and hold rights to governance and all utility of the system. It is important to note that we take a highly governance-minimized approach to designing trustless money in the same ethos as Bitcoin. We eschew DAO-like active management such as MakerDAO. The less parameters for a community to be able to actively manage, the less there is to disagree on. Parameters that are up for governance through FXS include adding/adjusting collateral pools, adjusting various fees (like minting or redeeming), and refreshing the rate of the collateral ratio. No other actions such as active management of collateral or addition of human-modifiable parameters are possible other than a hardfork that would require voluntarily moving to a new implementation entirely. ',
-    logoURI: 'https://app.sushi.com/images/tokens/fxs-square.jpg',
-    documentation: 'https://docs.frax.finance/',
   },
   cvxFXS: {
     name: 'Convex FXS',

--- a/src/api/rpc/chains.ts
+++ b/src/api/rpc/chains.ts
@@ -624,8 +624,8 @@ const fraxtalChain = {
   network: 'fraxtal',
   nativeCurrency: {
     decimals: 18,
-    name: 'Frax Staked Ether',
-    symbol: 'frxETH',
+    name: 'Frax',
+    symbol: 'FRAX',
   },
   rpcUrls: {
     public: { http: getRpcsForChain('fraxtal') },

--- a/src/data/fraxtal/curvePools.json
+++ b/src/data/fraxtal/curvePools.json
@@ -225,7 +225,7 @@
     ],
     "tokens": [
       {
-        "oracleId": "wfrxETH",
+        "oracleId": "frxETH",
         "decimals": "1e18"
       },
       {
@@ -273,7 +273,7 @@
         "decimals": "1e18"
       },
       {
-        "oracleId": "wfrxETH",
+        "oracleId": "frxETH",
         "decimals": "1e18"
       },
       {
@@ -387,7 +387,7 @@
         "decimals": "1e18"
       },
       {
-        "oracleId": "wfrxETH",
+        "oracleId": "frxETH",
         "decimals": "1e18"
       },
       {
@@ -410,7 +410,7 @@
     "getDy": ["v1", 0, 1],
     "tokens": [
       {
-        "oracleId": "wfrxETH",
+        "oracleId": "frxETH",
         "decimals": "1e18"
       },
       {

--- a/src/data/fraxtal/raPools.json
+++ b/src/data/fraxtal/raPools.json
@@ -35,7 +35,7 @@
     "lp1": {
       "address": "0xFC00000000000000000000000000000000000006",
       "oracle": "tokens",
-      "oracleId": "wfrxETH",
+      "oracleId": "frxETH",
       "decimals": "1e18"
     }
   },
@@ -55,7 +55,7 @@
     "lp1": {
       "address": "0xFC00000000000000000000000000000000000006",
       "oracle": "tokens",
-      "oracleId": "wfrxETH",
+      "oracleId": "frxETH",
       "decimals": "1e18"
     }
   },
@@ -75,7 +75,7 @@
     "lp1": {
       "address": "0xFC00000000000000000000000000000000000006",
       "oracle": "tokens",
-      "oracleId": "wfrxETH",
+      "oracleId": "frxETH",
       "decimals": "1e18"
     }
   }

--- a/src/utils/fetchChainLinkPrices.ts
+++ b/src/utils/fetchChainLinkPrices.ts
@@ -125,7 +125,9 @@ const oracles: Oracle[] = [
     heartbeat: 864000,
   },
   {
-    oracleId: 'FRAX',
+    // given this is on Ethereum, it is probably the price of LFRAX
+    // there is a new frxUSD token on Ethereum so this oracle might become outdated
+    oracleId: 'FRAX', // reminder: FRAX is oracle for frxUSD on Fraxtal
     address: '0xB9E1E3A9feFf48998E45Fa90847ed4D467E8BcfD',
     chain: 'ethereum',
     heartbeat: 3600,


### PR DESCRIPTION
Please bump address book in https://github.com/beefyfinance/beefy-v2/pull/2675 and deploy after this API PR is deployed.

Fraxtal:
- Rename FRAX name/symbol to frxUSD 
  - id/oracleId stays as FRAX so we don't lose historical data
- Rename wfrxETH name/symbol to frxETH
 - oracleId changed to frxETH (both existed previously)
- Rename FXS name/symbol to wFRAX
  - id/oracleId stays as FXS so we don't lose historical data
- Point WNATIVE to FXS (wFRAX)

Ethereum:
- add new frxUSD token (0xCAcd6fd266aF91b8AeD52aCCc382b4e165586E29)
  - oracleId is set to frxUSD but a) that already exists on Sonic, b) Legacy FRAX should be convertable to frxUSD 1:1, so perhaps we should only have one oracle, FRAX (which is the oracle of frxUSD now...)
- Update description of FRAX to indicate that it is now being called LFRAX/Legacy FRAX off chain
- Update description of FXS to indicate that is now being called FRAX off chain

Ethereum/Other chains:
- Haven't changed name or symbol, but maybe we should? Or have both some how like "frxUSD (p. FRAX)" and "FRAX (p. FXS)"

TLDR left ids and oracleIds as they are as much as possible, to keep historical data, however this results in a lot of confusion and will 100% lead to wrong oracleId being entered at some point in the future

@roman-monk help please

