### PR TITLE
merkl v4

### DIFF
--- a/src/api/offchain-rewards/index.ts
+++ b/src/api/offchain-rewards/index.ts
@@ -10,7 +10,7 @@ import { sendBadRequest, sendServiceUnavailable, sendSuccess } from '../../utils
 import { getVaultsByType } from '../stats/getMultichainVaults';
 import { serviceEventBus } from '../../utils/ServiceEventBus';
 import { Address } from 'viem';
-import { uniqBy } from 'lodash';
+import { sortBy, uniqBy } from 'lodash';
 
 const TIME_BETWEEN_UPDATES = 10 * 60; // seconds
 const CACHE_KEY = 'OFFCHAIN_REWARDS';
@@ -139,6 +139,7 @@ function makeRequestHandler(options: { chain: boolean; active: boolean }) {
   const filterCampaigns = options.active
     ? (campaigns: ReadonlyArray<Campaign>) => campaigns.filter(campaign => campaign.active)
     : (campaigns: ReadonlyArray<Campaign>) => campaigns;
+  const sortCampaigns = (campaigns: ReadonlyArray<Campaign>) => sortBy(campaigns, c => c.id);
 
   return async (ctx: Context) => {
     const meta = await getMeta(ctx);
@@ -151,7 +152,7 @@ function makeRequestHandler(options: { chain: boolean; active: boolean }) {
       return;
     }
 
-    const campaigns = filterCampaigns(meta.campaigns);
+    const campaigns = sortCampaigns(filterCampaigns(meta.campaigns));
     sendSuccess(ctx, campaigns, {
       maxAge: 5 * 60,
     });

--- a/src/api/offchain-rewards/providers/merkl/types.ts
+++ b/src/api/offchain-rewards/providers/merkl/types.ts
@@ -2,59 +2,221 @@ import { AppChain } from '../../../../utils/chain';
 import { CampaignType } from '../../types';
 
 type MerklApiForwarder = {
-  almAPR: number;
-  almAddress: string;
-  forwarderType: number;
-  priority: number;
+  token?: string;
   sender: string;
-  target: string;
-  owner: string;
-  type: number;
+  priority: number;
+  forwarderType: number;
+  type?: number;
+  target?: string;
+  owner?: string;
 };
 
-type MerklApiCampaignParameters = {
+export type MerklApiCampaignType =
+  | 'INVALID'
+  | 'ERC20'
+  | 'CLAMM'
+  | 'ERC20_SNAPSHOT'
+  | 'JSON_AIRDROP'
+  | 'SILO'
+  | 'RADIANT'
+  | 'MORPHO'
+  | 'DOLOMITE'
+  | 'BADGER'
+  | 'COMPOUND'
+  | 'AJNA'
+  | 'EULER'
+  | 'UNISWAP_V4'
+  | 'ION'
+  | 'EIGENLAYER'
+  | 'ERC20TRANSFERS'
+  | 'ERC20LOGPROCESSOR'
+  | 'ERC20REBASELOGPROCESSOR'
+  | 'VEST'
+  | 'ERC20_FIX_APR'
+  | 'HYPERDRIVELOGPROCESSOR'
+  | 'HYPERDRIVELOGFIXPROCESSOR';
+
+export type MerklApiCampaignParams = {
+  amm?: number;
+  url?: string;
+  hooks?: any[];
+  token0?: string;
+  token1?: string;
+  ammAlgo?: number;
+  poolFee?: string;
+  duration?: number;
+  blacklist?: string[];
+  whitelist?: string[];
+  forwarders: MerklApiForwarder[];
+  weightFees?: number;
+  poolAddress?: string;
+  symbolToken0?: string;
+  symbolToken1?: string;
+  weightToken0?: number;
+  weightToken1?: number;
+  decimalsToken0?: number;
+  decimalsToken1?: number;
   symbolRewardToken: string;
   decimalsRewardToken: number;
+  isOutOfRangeIncentivized?: boolean;
+  targetToken?: string;
+  symbolTargetToken?: string;
+  decimalsTargetToken?: number;
+  jsonUrl?: string;
+  boostedReward?: number;
+  boostedAddress?: string;
 };
 
-export enum MerklApiCampaignType {
-  ERC20 = 1,
-  ConcentratedLiquidity,
-  ERC20Snapshot,
-  Airdrops,
-  Silo,
-  Radiant,
-  Morpho,
-  Dolomite,
-  Badger,
-  CompoundV2,
-  Anja,
-  EulerFinance,
+export interface MerklApiChain {
+  id: number;
+  name: string;
+  icon: string;
+}
+
+export interface MerklApiToken {
+  id: string;
+  name: string;
+  chainId: number;
+  address: string;
+  decimals: number;
+  icon: string;
+  verified: boolean;
+  isTest: boolean;
+  isPoint: boolean;
+  isNative: boolean;
+  price?: number | null;
+  symbol: string;
+}
+
+export interface MerklApiCampaignStatus {
+  campaignId: string;
+  computedUntil: number;
+  processingStarted: number;
+  status: string;
+  error: string;
+  details: string | Record<string, unknown>; // string = "{json encoded object}" or "null"
 }
 
 export type MerklApiCampaign = {
-  chainId: number;
-  computeChainId?: number;
-  campaignType: MerklApiCampaignType;
+  id: string;
+  computeChainId: number;
+  distributionChainId: number;
   campaignId: string;
-  creator: string;
+  type: MerklApiCampaignType;
+  distributionType: string;
+  subType: number;
+  rewardTokenId: string;
+  amount: string;
+  opportunityId: string;
   startTimestamp: number;
   endTimestamp: number;
-  rewardToken: string;
-  /** supposed to be an address but some have extra space on end */
-  mainParameter: string;
-  forwarders: MerklApiForwarder[];
-  campaignParameters: MerklApiCampaignParameters;
-  apr: number; // used on erc20 campaigns on standard vaults
+  creator: {
+    address: string;
+    tags: string[];
+    creatorId: string;
+  };
+  params: MerklApiCampaignParams;
+  chain: MerklApiChain;
+  rewardToken: MerklApiToken;
+  distributionChain: MerklApiChain;
+  campaignStatus: MerklApiCampaignStatus;
 };
 
-export type MerklApiCampaignsResponse = {
-  [chainId: string]: {
-    [poolTypeId: string]: {
-      [campaignId: string]: MerklApiCampaign;
-    };
-  };
+export type MerklApiProtocol = {
+  id: string;
+  tags: string[];
+  name: string;
+  description: string;
+  url: string;
+  icon: string;
 };
+
+export type MerklApiAprBreakdown = {
+  id: number;
+  identifier: string;
+  type: string;
+  value: number;
+  aprRecordId: string;
+};
+
+export type MerklApiApr = {
+  cumulated: number;
+  timestamp: string;
+  breakdowns: MerklApiAprBreakdown[];
+};
+
+export type MerklApiTvlBreakdown = {
+  id: number;
+  identifier: string;
+  type: string;
+  value: number;
+  tvlRecordId: string;
+};
+
+export type MerklApiTvl = {
+  id: string;
+  total: number;
+  timestamp: string;
+  breakdowns: MerklApiTvlBreakdown[];
+};
+
+export type MerklApiRewardsBreakdown = {
+  token: MerklApiToken;
+  amount: string;
+  id: number;
+  value: number;
+  campaignId: string;
+  dailyRewardsRecordId: string;
+};
+
+export type MerklApiRewards = {
+  id: string;
+  total: number;
+  timestamp: string;
+  breakdowns: MerklApiRewardsBreakdown[];
+};
+
+export type MerklApiOpportunityStatus = 'LIVE' | 'SOON' | 'PAST';
+
+export type MerklApiOpportunityWithCampaigns = {
+  chainId: number;
+  type: string;
+  identifier: string;
+  name: string;
+  status: MerklApiOpportunityStatus;
+  action: string;
+  tvl: number;
+  apr: number;
+  dailyRewards: number;
+  tags: string[];
+  id: string;
+  tokens: MerklApiToken[];
+  chain: MerklApiChain;
+  protocol?: MerklApiProtocol;
+  aprRecord: MerklApiApr;
+  campaigns: MerklApiCampaign[];
+  tvlRecord?: MerklApiTvl;
+  rewardsRecord?: MerklApiRewards;
+};
+
+export type MerklApiOpportunitiesRequest = {
+  page: number;
+  items: number;
+  chainId: number;
+  type: MerklApiCampaignType[];
+};
+
+export type MerklApiOpportunitiesParams = {
+  [K in keyof MerklApiOpportunitiesRequest]: string;
+} & {
+  status: MerklApiOpportunityStatus;
+  test: 'false';
+  campaigns: 'true';
+};
+
+export type MerklApiCampaignsResponse = Array<MerklApiCampaign>;
+
+export type MerklApiOpportunitiesWithCampaignsResponse = Array<MerklApiOpportunityWithCampaigns>;
 
 export type CampaignTypeByChain = {
   [K in AppChain]?: CampaignType;

--- a/src/api/offchain-rewards/types.ts
+++ b/src/api/offchain-rewards/types.ts
@@ -1,5 +1,6 @@
 import { AppChain } from '../../utils/chain';
 import { Address } from 'viem';
+import { MerklApiCampaignStatus } from './providers/merkl/types';
 
 export type ProviderId = 'merkl' | 'stellaswap';
 
@@ -45,6 +46,8 @@ export type MerklCampaign = MakeCampaign<
   'merkl',
   {
     campaignId: string;
+    opportunityId: string;
+    campaignStatus?: Pick<MerklApiCampaignStatus, 'computedUntil' | 'processingStarted' | 'status'>;
   }
 >;
 


### PR DESCRIPTION
merkl no longer provides per campaign apr for each forwarder, so the split between rewards is being guessed at using the ratio of the average apr per campaign over average apr per opportunity