### PR TITLE
Fee memory optimization

### DIFF
--- a/src/api/rpc/rpcs.ts
+++ b/src/api/rpc/rpcs.ts
@@ -166,12 +166,7 @@ const rpcs: Record<ChainId, string[]> = {
     'https://kava-evm.publicnode.com',
     'https://kava-pokt.nodies.app',
   ],
-  [ChainId.canto]: [
-    'https://canto.gravitychain.io',
-    'https://jsonrpc.canto.nodestake.top',
-    'https://canto.slingshot.finance',
-    'https://mainnode.plexnode.org:8545',
-  ],
+  [ChainId.canto]: ['https://canto-rpc.ansybl.io'],
   [ChainId.zksync]: [
     'https://mainnet.era.zksync.io',
     'https://zksync.drpc.org',

--- a/src/api/zap/swap/blocked-tokens.ts
+++ b/src/api/zap/swap/blocked-tokens.ts
@@ -609,7 +609,6 @@ export const blockedTokensByChain: Record<SupportedApiChain, Set<string>> = {
   lisk: new Set([]),
   sonic: new Set([]),
   berachain: new Set([]),
-  unichain: new Set([]),
   saga: new Set([addressBook.saga.tokens.WGAS.address]),
   hyperevm: new Set([]),
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,7 +62,7 @@ const DEFAULT_RPCS: ApiChainToRpcs = {
   lisk: ['https://rpc.api.lisk.com'],
   sonic: ['https://rpc.soniclabs.com'],
   berachain: ['https://rpc.berachain.com'],
-  unichain: ['https://mainnet.unichain.org'],
+  // unichain: ['https://mainnet.unichain.org'],
   saga: ['https://sagaevm.jsonrpc.sagarpc.io'],
   hyperevm: ['https://rpc.hyperliquid.xyz/evm'],
 } as const;

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -6,7 +6,7 @@ export type ApiChain = keyof typeof ChainId;
 export type AppChain = Exclude<ApiChain, 'one'> | 'harmony';
 export type AnyChain = AppChain | ApiChain;
 
-const DEPRECATED_CHAINS = ['heco', 'real', 'one'] as const;
+const DEPRECATED_CHAINS = ['heco', 'real', 'one', 'unichain'] as const;
 
 export type SupportedApiChain = Exclude<ApiChain, (typeof DEPRECATED_CHAINS)[number]>;
 

--- a/src/utils/multicallHelpers.ts
+++ b/src/utils/multicallHelpers.ts
@@ -33,7 +33,6 @@ export const MULTICALL_V3: Partial<Readonly<Record<ChainId, string>>> = {
   [ChainId.lisk]: '0xcA11bde05977b3631167028862bE2a173976CA11',
   [ChainId.sonic]: '0xcA11bde05977b3631167028862bE2a173976CA11',
   [ChainId.berachain]: '0xcA11bde05977b3631167028862bE2a173976CA11',
-  [ChainId.unichain]: '0xcA11bde05977b3631167028862bE2a173976CA11',
   [ChainId.saga]: '0x864DDc9B50B9A0dF676d826c9B9EDe9F8913a160',
   [ChainId.hyperevm]: '0xcA11bde05977b3631167028862bE2a173976CA11',
 };


### PR DESCRIPTION
On fee updates:
- Process chains sequentially
- Removed usage of BigNumbers
- Batch up each individual chain's requests in batches of 128 vaults at a time