### PR TITLE
Add MegaETH AaveV3 USDm

### DIFF
--- a/src/api/stats/getNonAmmPrices.ts
+++ b/src/api/stats/getNonAmmPrices.ts
@@ -45,6 +45,7 @@ import {
   FRAXTAL_CHAIN_ID as FRX_CHAIN_ID,
   GNOSIS_CHAIN_ID as GNO_CHAIN_ID,
   MANTLE_CHAIN_ID,
+  MEGAETH_CHAIN_ID,
   MONAD_CHAIN_ID,
   OPTIMISM_CHAIN_ID,
   PLASMA_CHAIN_ID,
@@ -119,6 +120,7 @@ export async function getNonAmmPrices(
 
   const promises = [
     getAaveV3Prices(MANTLE_CHAIN_ID, require('../../data/mantle/aaveV3Pools.json'), tokenPrices),
+    getAaveV3Prices(MEGAETH_CHAIN_ID, require('../../data/megaeth/aaveV3Pools.json'), tokenPrices),
     getGearboxPrices(MONAD_CHAIN_ID, require('../../data/monad/gearboxPools.json'), tokenPrices),
     getNeverlandPrices(tokenPrices),
     getCurvanceMonadPrices(tokenPrices),

--- a/src/api/stats/megaeth/getAaveV3Apys.js
+++ b/src/api/stats/megaeth/getAaveV3Apys.js
@@ -1,0 +1,13 @@
+const { getAaveV3ApyData } = require('../common/aave/getAaveV3Apys');
+const pools = require('../../../data/megaeth/aaveV3Pools.json');
+const { MEGAETH_CHAIN_ID } = require('../../../constants');
+
+const config = {
+  dataProvider: '0x9588b453A4EE24a420830CB3302195cA7aA3b403',
+  incentives: '0x3691FF69e22c1353df9F8b2c0B1B16aA5fEEc389',
+  rewards: [],
+};
+
+export const getAaveV3Apys = async () => {
+  return getAaveV3ApyData(config, pools, MEGAETH_CHAIN_ID);
+};

--- a/src/api/stats/megaeth/index.js
+++ b/src/api/stats/megaeth/index.js
@@ -1,7 +1,8 @@
 const { getBeefyCowMegaethApys } = require('./getBeefyCowMegaethApys');
+const { getAaveV3Apys } = require('./getAaveV3Apys');
 const { MEGAETH_CHAIN_ID } = require('../../../constants');
 
-const getApys = [getBeefyCowMegaethApys];
+const getApys = [getBeefyCowMegaethApys, getAaveV3Apys];
 
 const getMegaethApys = async () => {
   const start = Date.now();

--- a/src/data/megaeth/aaveV3Pools.json
+++ b/src/data/megaeth/aaveV3Pools.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "aavev3-megaeth-usdm",
+    "token": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+    "aToken": "0x5dF82810CB4B8f3e0Da3c031cCc9208ee9cF9500",
+    "debtToken": "0x6b408D6C479C304794abc60A4693A3aD2D3C2D0D",
+    "oracle": "tokens",
+    "oracleId": "USDm",
+    "decimals": "1e18",
+    "borrowDepth": 1,
+    "borrowPercent": 0,
+    "skimLending": true
+  }
+]

--- a/src/data/megaeth/aaveV3Pools.json
+++ b/src/data/megaeth/aaveV3Pools.json
@@ -4,6 +4,7 @@
     "token": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
     "aToken": "0x5dF82810CB4B8f3e0Da3c031cCc9208ee9cF9500",
     "debtToken": "0x6b408D6C479C304794abc60A4693A3aD2D3C2D0D",
+    "identifier": "7d445104efdd2da0",
     "oracle": "tokens",
     "oracleId": "USDm",
     "decimals": "1e18",


### PR DESCRIPTION
Adding Aave APYs to MegaETH, and USDm vault. Will add Merkl campaign id when it goes live.