### PR TITLE
Add 4 x Ethereum Morpho V2 Steakhouse Vaults

### DIFF
--- a/packages/address-book/src/address-book/ethereum/tokens/tokens.ts
+++ b/packages/address-book/src/address-book/ethereum/tokens/tokens.ts
@@ -3032,4 +3032,18 @@ export const tokens = {
     bridge: 'native',
     tags: ['NO_TIMELOCK', 'STABLECOIN', 'SYNTHETIC'],
   },
+  AUSD: {
+    name: 'AUSD',
+    symbol: 'AUSD',
+    oracleId: 'ethAUSD',
+    address: '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a',
+    chainId: 1,
+    decimals: 6,
+    website: 'https://agora.finance/',
+    documentation: 'https://developer.agora.finance/',
+    description:
+      'AUSD is backed 100% by Agora’s Reserves. The Agora Reserve Fund is composed of cash, overnight repurchase and reverse repurchase agreements, and short-term U.S. Treasury securities.',
+    bridge: 'native',
+    tags: ['NO_TIMELOCK', 'STABLECOIN'],
+  },
 } as const satisfies Record<string, Token>;

--- a/src/data/ethereum/morphoPools.json
+++ b/src/data/ethereum/morphoPools.json
@@ -1,5 +1,14 @@
 [
   {
+    "name": "morpho-v2-ethereum-steakhouse-prime-instant-pyusd",
+    "address": "0xbeef00B5d83C1188F07A5184230a805639c39f04",
+    "oracle": "tokens",
+    "oracleId": "PYUSD",
+    "decimals": "1e6",
+    "v2": true,
+    "skim": true
+  },
+  {
     "name": "morpho-v2-ethereum-steakhouse-high-yield-usdt",
     "address": "0xbeeff07d991C04CD640DE9F15C08ba59c4FEDEb7",
     "oracle": "tokens",
@@ -14,15 +23,6 @@
     "oracle": "tokens",
     "oracleId": "ethAUSD",
     "decimals": "1e6",
-    "v2": true,
-    "skim": true
-  },
-  {
-    "name": "morpho-v2-ethereum-steakhouse-prime-frxusd",
-    "address": "0xbeef009FF4FB1727297BF2526806F4A73E4b99aD",
-    "oracle": "tokens",
-    "oracleId": "frxUSD",
-    "decimals": "1e18",
     "v2": true,
     "skim": true
   },

--- a/src/data/ethereum/morphoPools.json
+++ b/src/data/ethereum/morphoPools.json
@@ -1,5 +1,41 @@
 [
   {
+    "name": "morpho-v2-ethereum-steakhouse-high-yield-usdt",
+    "address": "0xbeeff07d991C04CD640DE9F15C08ba59c4FEDEb7",
+    "oracle": "tokens",
+    "oracleId": "USDT",
+    "decimals": "1e6",
+    "v2": true,
+    "skim": true
+  },
+  {
+    "name": "morpho-v2-ethereum-steakhouse-high-yield-instant-ausd",
+    "address": "0xbEeFf89ABb7815cCD5182BD1FF82C4a4F8FCb13D",
+    "oracle": "tokens",
+    "oracleId": "ethAUSD",
+    "decimals": "1e6",
+    "v2": true,
+    "skim": true
+  },
+  {
+    "name": "morpho-v2-ethereum-steakhouse-prime-frxusd",
+    "address": "0xbeef009FF4FB1727297BF2526806F4A73E4b99aD",
+    "oracle": "tokens",
+    "oracleId": "frxUSD",
+    "decimals": "1e18",
+    "v2": true,
+    "skim": true
+  },
+  {
+    "name": "morpho-v2-ethereum-steakhouse-high-yield-usdc",
+    "address": "0xbeeff2C5bF38f90e3482a8b19F12E5a6D2FCa757",
+    "oracle": "tokens",
+    "oracleId": "USDC",
+    "decimals": "1e6",
+    "v2": true,
+    "skim": true
+  },
+  {
     "name": "morpho-eth-sentora-pyusd",
     "address": "0xb576765fB15505433aF24FEe2c0325895C559FB2",
     "oracle": "tokens",

--- a/src/utils/fetchConcentratedLiquidityTokenPrices.ts
+++ b/src/utils/fetchConcentratedLiquidityTokenPrices.ts
@@ -114,6 +114,14 @@ const tokens: Partial<Record<keyof typeof ChainId, ConcentratedLiquidityToken[]>
       firstToken: 'USDC',
       secondToken: 'EURCV',
     },
+    {
+      type: 'UniV3',
+      oracleId: 'ethAUSD',
+      decimalDelta: 1,
+      pool: '0xbafead7c60ea473758ed6c6021505e8bbd7e8e5d',
+      firstToken: 'USDC',
+      secondToken: 'ethAUSD',
+    },
   ],
   polygon: [
     {


### PR DESCRIPTION
### setOracle(AUSD)
```
0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a 
0xc1C6760f4317C711Ded47678bA96fe487DB91f91
0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4800000000000000000000000000000000efe302beaa2b3e6e1b18d08d69a9012a0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000bafead7c60ea473758ed6c6021505e8bbd7e8e5d0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000012c
```
### setSwapInfo(AUSD => USDC => WETH)
```
0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a 
0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 
[
'0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45',
'0xb858183f000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000830df56616d58976a12d19d283b40e25beefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004200000000efe302beaa2b3e6e1b18d08d69a9012a000064a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480001f4c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000000000000000000000000000000000000000',
100,
132,
0
]
```
### setSwapInfo(USDT => USDC => WETH)
```
0xdAC17F958D2ee523a2206206994597C13D831ec7 
0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 
[
'0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45',
'0xb858183f000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000830df56616d58976a12d19d283b40e25beefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000042dac17f958d2ee523a2206206994597c13d831ec7000064a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480001f4c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000000000000000000000000000000000000000',
100,
132,
0
]
```

I'm not too sure why, but PYUSD harvest seems to be failing because there isn't a swap route from PYUSD to USDC (even though there is one to WETH). So providing that route too:

### setSwapInfo(PYUSD => USDC)
```
0x6c3ea9036406852006290770BEdFcAbA0e23A0e8 
0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 
[
'0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45',
'0xb858183f000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000830df56616d58976a12d19d283b40e25beefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002b6c3ea9036406852006290770bedfcaba0e23a0e8000064a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000000000000000000000',
100,
132,
0
]
```