### PR TITLE
Add Arbitrum Uniswap V3 WBTC-cbBTC CLM

### DIFF
--- a/packages/address-book/src/address-book/arbitrum/tokens/tokens.ts
+++ b/packages/address-book/src/address-book/arbitrum/tokens/tokens.ts
@@ -2356,7 +2356,7 @@ export const tokens = {
   cbBTC: {
     name: 'Coinbase Wrapped BTC',
     symbol: 'cbBTC',
-    oracleId: 'cbBTC',
+    oracleId: 'arbcbBTC',
     address: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
     chainId: 42161,
     decimals: 8,

--- a/packages/address-book/src/address-book/arbitrum/tokens/tokens.ts
+++ b/packages/address-book/src/address-book/arbitrum/tokens/tokens.ts
@@ -2353,4 +2353,17 @@ export const tokens = {
     bridge: 'layer-zero',
     tags: ['NO_TIMELOCK'],
   },
+  cbBTC: {
+    name: 'Coinbase Wrapped BTC',
+    symbol: 'cbBTC',
+    oracleId: 'cbBTC',
+    address: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
+    chainId: 42161,
+    decimals: 8,
+    website: 'https://www.coinbase.com/',
+    description:
+      'Coinbase Wrapped Bitcoin (cbBTC) is backed 1:1 with Bitcoin, custodied with Coinbase.',
+    documentation: 'https://www.coinbase.com/blog/coinbase-wrapped-btc-cbbtc-is-now-live',
+    bridge: 'native',
+  },
 } as const satisfies Record<string, Token>;

--- a/src/data/arbitrum/beefyCowVaults.json
+++ b/src/data/arbitrum/beefyCowVaults.json
@@ -15,7 +15,7 @@
     "address": "0x618D9328EB1D06dFfD2CB4B67523b2cB5740e32f",
     "lpAddress": "0x9B42809aaaE8d088eE01FE637E948784730F0386",
     "tokens": ["0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f", "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"],
-    "tokenOracleIds": ["WBTC", "cbBTC"],
+    "tokenOracleIds": ["WBTC", "arbcbBTC"],
     "decimals": [8, 8],
     "oracleId": "uniswap-cow-arbitrum-wbtc-cbbtc",
     "rewardPool": {

--- a/src/data/arbitrum/beefyCowVaults.json
+++ b/src/data/arbitrum/beefyCowVaults.json
@@ -12,6 +12,18 @@
     }
   },
   {
+    "address": "0x618D9328EB1D06dFfD2CB4B67523b2cB5740e32f",
+    "lpAddress": "0x9B42809aaaE8d088eE01FE637E948784730F0386",
+    "tokens": ["0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f", "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"],
+    "tokenOracleIds": ["WBTC", "cbBTC"],
+    "decimals": [8, 8],
+    "oracleId": "uniswap-cow-arbitrum-wbtc-cbbtc",
+    "rewardPool": {
+      "address": "0x6B29227D91F1317bb945FbCC87B37ef39d04C5f8",
+      "oracleId": "uniswap-cow-arbitrum-wbtc-cbbtc-rp"
+    }
+  },
+  {
     "address": "0x1076C9156e555a122d9cad36f98BB3CB5186Af18",
     "lpAddress": "0xE42e41985A07579E1A09092fA042455d40Bf5A75",
     "tokens": ["0x0C1c1C109FE34733fca54b82d7B46B75CFb71F6e", "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"],

--- a/src/utils/fetchConcentratedLiquidityTokenPrices.ts
+++ b/src/utils/fetchConcentratedLiquidityTokenPrices.ts
@@ -160,6 +160,14 @@ const tokens: Partial<Record<keyof typeof ChainId, ConcentratedLiquidityToken[]>
   arbitrum: [
     {
       type: 'UniV3',
+      oracleId: 'arbcbBTC',
+      decimalDelta: 1,
+      pool: '0x9b42809aaae8d088ee01fe637e948784730f0386',
+      firstToken: 'WBTC',
+      secondToken: 'arbcbBTC',
+    },
+    {
+      type: 'UniV3',
       oracleId: 'GNS',
       decimalDelta: 1,
       pool: '0xC91B7b39BBB2c733f0e7459348FD0c80259c8471',


### PR DESCRIPTION
New token: **cbBTC** on Arbitrum
Token address: `0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf`
Pool: WBTC/cbBTC Uniswap V3 0.01% — `0x9B42809aaaE8d088eE01FE637E948784730F0386`

Per @<reviewer>'s feedback (thanks!), this revision uses an Arbitrum-specific `arbcbBTC` oracleId so cbBTC on Arbitrum is priced independently from cbBTC on other chains, and the on-chain oracle reads the cbBTC/WBTC UniV3 pool TWAP rather than the Chainlink BTC/USD feed. Pool observation cardinality has been bumped to 360.

CLM deployment on Arbitrum mainnet:

| Contract | Address |
|---|---|
| Vault | [`0x618D9328EB1D06dFfD2CB4B67523b2cB5740e32f`](https://arbiscan.io/address/0x618D9328EB1D06dFfD2CB4B67523b2cB5740e32f) |
| Strategy | [`0x2a25771642EaBD9EBEa7245d578E5D813D5301e7`](https://arbiscan.io/address/0x2a25771642EaBD9EBEa7245d578E5D813D5301e7) |
| Reward pool | [`0x6B29227D91F1317bb945FbCC87B37ef39d04C5f8`](https://arbiscan.io/address/0x6B29227D91F1317bb945FbCC87B37ef39d04C5f8) |

Strategy params: `positionWidth=20`, `maxTickDeviation=2`, `twapInterval=120`. Vault owner = `0x9A94…BdaD` (vaultOwner), strategy owner = `0x6d28afD…D89F` (strategyOwner), reward pool owner = `0xf7EC…CCcd` (devMultisig). Strategist = my ledger.

---

**Pool observation cardinality bump (done — no keeper action needed)**

`pool.increaseObservationCardinalityNext(360)` was called from the deployer wallet to support a 360-second TWAP on the new oracle wiring (Beefy's default for CLMs). Tx: [`0x58acbd28bc459236b8f6f52cf001fa4086c46de8fe91f7370e9020da8fb248a4`](https://arbiscan.io/tx/0x58acbd28bc459236b8f6f52cf001fa4086c46de8fe91f7370e9020da8fb248a4). `observationCardinalityNext` is now `360` (current `observationCardinality` grows organically as the pool gets used).

---

**Pre-activation wiring required** (keeper multisig `0x4fED5491693007f0CD49f4614FFC38Ab6A04B619` to execute on Arbitrum):

cbBTC needs to be wired into Beefy oracle (UniV3 pool TWAP) and into BeefySwapper so harvest can convert cbBTC fees to WETH.

**setOracle** on BeefyOracle `0x5C7c7Bb0c9251821cB5a1D9c08F21B0DAD5efe65`:

```
0x6d64a420000000000000000000000000cbb7c0000ab88b473b1f5afd9ef808440eed33bf0000000000000000000000003ea93706827c7009604a7cad51622ad99387869000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000020000000000000000000000002f2a2543b76a4166549f7aab2e75bef0aefc5b0f000000000000000000000000cbb7c0000ab88b473b1f5afd9ef808440eed33bf00000000000000000000000000000000000000000000000000000000000000010000000000000000000000009b42809aaae8d088ee01fe637e948784730f038600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000168
```

Decoded: `setOracle(cbBTC, beefyOracleUniswapV3 0x3EA93706…, abi.encode([WBTC, cbBTC], [0x9b42…pool], [360s TWAP]))` — prices cbBTC against WBTC using the same pool we're vaulting (the deepest cbBTC liquidity on Arbitrum), with a 360-second TWAP.

**setSwapInfo** on BeefySwapper `0xCee843CD04E3758dDC5BCFf08647DddB117151D0`:

```
0xb84ea773000000000000000000000000cbb7c0000ab88b473b1f5afd9ef808440eed33bf00000000000000000000000082af49447d8a07e3bd95bd0d56f35241523fbab1000000000000000000000000e592427a0aece92de3edee1f18e0157c0586156400000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000008400000000000000000000000000000000000000000000000000000000000000a400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000144c04b8d59000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000cee843cd04e3758ddc5bcff08647dddb117151d0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000042cbb7c0000ab88b473b1f5afd9ef808440eed33bf0000642f2a2543b76a4166549f7aab2e75bef0aefc5b0f0001f482af49447d8a07e3bd95bd0d56f35241523fbab100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```

Decoded: cbBTC → WETH via Uniswap V3 SwapRouter (cbBTC → WBTC at 0.01% → WETH at 0.05%), `amountIndex=132`, `minIndex=164`, `minAmountSign=0`.

Both calldata strings were fork-validated end-to-end (impersonated keeper on Arbitrum fork, applied both, then harvested with simulated swap volume — fees flowed correctly to caller / Beefy fee recipient / strategist).

---

**Mainnet lifecycle test** (deployer `0x2cF7…be4d`, all phases executed on Arbitrum):

| Phase | Tx |
|---|---|
| Deposit (~$170 WBTC + ~$160 cbBTC → 7006 shares) | [`0x4108d4e…44766`](https://arbiscan.io/tx/0x4108d4e00b9e9f895500a65e8884f22394a97374bbfb475b77b41923ce244766) |
| `strategy.panic(0,0)` (paused=true, LP emptied to idle) | [`0x84ce5cf…f0b2e`](https://arbiscan.io/tx/0x84ce5cf3b3edfe201071cf56062553b72b13d7a6f0550fc916df293ec7ef0b2e) |
| `vault.withdrawAll(0,0)` (7006 shares → 3606 WBTC + 3411 cbBTC, ≈ 87.5% of vault) | [`0x12b342e…17699`](https://arbiscan.io/tx/0x12b342e80bb94728ce637c13eebe106bb8ca2205a6bfc6c37b0c32c036417699) |
| `strategy.unpause()` (paused=false, isCalm=true, burn-share backing redeployed) | [`0xea58aec…fde22`](https://arbiscan.io/tx/0xea58aec19c376f828482c4a9bec4ee27b43f34fa9e6c1be0cdc44f28790fde22) |
| Redeposit (6801 shares minted, positions rebuilt) | [`0xfd75d6b…89a5e`](https://arbiscan.io/tx/0xfd75d6bdfc65173107f7bfc2295ed81e8c76bbf06a3c8d926f6055ad73489a5e) |
| Strategy ownership → Beefy strategyOwner (after lifecycle test, as required) | [`0x7ff5b1c…5cf8f`](https://arbiscan.io/tx/0x7ff5b1c658a62b16f8a56c9afbabee48dbbb1dc8444c1c6efd7846d3dca5cf8f) |
| Pool observation cardinality bump (post-PR-review feedback) | [`0x58acbd28…48a4`](https://arbiscan.io/tx/0x58acbd28bc459236b8f6f52cf001fa4086c46de8fe91f7370e9020da8fb248a4) |

Final vault state: 6801 deployer shares (of 7801 total — 1000 are the standard MINIMUM_LIQUIDITY burn shares), pool holds 3907 WBTC + 3892 cbBTC across main+alt, `isCalm=true`, `paused=false`.

Local validators pass: `npm run prettier --check`, `npm run test:ts`, `npm run checksum` (packages/address-book), `npm run checkClms`.

Front-end PR: beefyfinance/beefy-v2#3138
