### PR TITLE
Add 3 x Ethereum CLMs

### DIFF
--- a/src/api/cowcentrated/getCowClms.ts
+++ b/src/api/cowcentrated/getCowClms.ts
@@ -21,6 +21,7 @@ import hyperevmPools from '../../data/hyperevm/beefyCowVaults.json';
 import plasmaPools from '../../data/plasma/beefyCowVaults.json';
 import monadPools from '../../data/monad/beefyCowVaults.json';
 import megaethPools from '../../data/megaeth/beefyCowVaults.json';
+import ethereumPools from '../../data/ethereum/beefyCowVaults.json';
 const chainToClms: Readonly<Partial<Record<ApiChain, CowClm[]>>> = {
   optimism: validateCowClms(optimismPools),
   base: validateCowClms(basePools),
@@ -43,6 +44,7 @@ const chainToClms: Readonly<Partial<Record<ApiChain, CowClm[]>>> = {
   plasma: validateCowClms(plasmaPools),
   monad: validateCowClms(monadPools),
   megaeth: validateCowClms(megaethPools),
+  ethereum: validateCowClms(ethereumPools),
 };
 
 const chainsWithClms = (Object.keys(chainToClms) as ReadonlyArray<ApiChain>).filter(

--- a/src/api/stats/ethereum/getBeefyEthereumCowApys.ts
+++ b/src/api/stats/ethereum/getBeefyEthereumCowApys.ts
@@ -1,0 +1,5 @@
+import { getCowApys } from '../common/getCowVaultApys';
+
+export const getBeefyEthereumCowApys = async () => {
+  return await getCowApys('ethereum');
+};

--- a/src/api/stats/ethereum/index.js
+++ b/src/api/stats/ethereum/index.js
@@ -1,3 +1,4 @@
+const { getBeefyEthereumCowApys } = require('./getBeefyEthereumCowApys');
 const { getAuraApys } = require('./getAuraApys');
 const { getConvexApys } = require('./getConvexApys');
 const { getConvexCrvApy } = require('./getConvexCrvApy');
@@ -16,6 +17,7 @@ const { getPendleApys } = require('../common/pendle/getPendleApys');
 const { getPendleUnboostedApys } = require('../common/pendle/getPendleUnboostedApys');
 
 const getApys = [
+  getBeefyEthereumCowApys,
   getAuraApys,
   getbeQIApy,
   getCurveApys,

--- a/src/data/ethereum/beefyCowVaults.json
+++ b/src/data/ethereum/beefyCowVaults.json
@@ -1,0 +1,38 @@
+[
+  {
+    "address": "0xC7AFdB8Ef47C058E8F4094Cca09080BcAb662e80",
+    "lpAddress": "0xCBCdF9626bC03E24f779434178A73a0B4bad62eD",
+    "tokens": ["0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"],
+    "tokenOracleIds": ["WBTC", "WETH"],
+    "decimals": [8, 18],
+    "oracleId": "uniswap-cow-ethereum-wbtc-weth",
+    "rewardPool": {
+      "address": "0xef958e249c089fb2c378fdf5fedfb8a6d6374000",
+      "oracleId": "uniswap-cow-ethereum-wbtc-weth-rp"
+    }
+  },
+  {
+    "address": "0x136363cA1219c943a560F22EEfbb2bEB4c92Ef3c",
+    "lpAddress": "0x99ac8cA7087fA4A2A1FB6357269965A2014ABc35",
+    "tokens": ["0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"],
+    "tokenOracleIds": ["WBTC", "USDC"],
+    "decimals": [8, 6],
+    "oracleId": "uniswap-cow-ethereum-wbtc-usdc",
+    "rewardPool": {
+      "address": "0x7431d63132167d3ddd7990a90e26601d3ea9e6eb",
+      "oracleId": "uniswap-cow-ethereum-wbtc-usdc-rp"
+    }
+  },
+  {
+    "address": "0xDcfBFc35173EcF5A4451f86600b741cc365Ceb60",
+    "lpAddress": "0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36",
+    "tokens": ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "0xdAC17F958D2ee523a2206206994597C13D831ec7"],
+    "tokenOracleIds": ["WETH", "USDT"],
+    "decimals": [18, 6],
+    "oracleId": "uniswap-cow-ethereum-weth-usdt",
+    "rewardPool": {
+      "address": "0x8e15fcaa3eb4f7b111c4d3dd237b36ca49331786",
+      "oracleId": "uniswap-cow-ethereum-weth-usdt-rp"
+    }
+  }
+]


### PR DESCRIPTION
~Awaiting addition of Ethereum to CLM API to display APYs.~ **Edit:** Now showing correctly in API.

[V2 PR](https://github.com/beefyfinance/beefy-v2/pull/3165)

**Edit:** routes + oracle set by DefiD.

### ~setOracle( WBTC) [UniV3]~
```
0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599,
0xc1C6760f4317C711Ded47678bA96fe487DB91f91,
0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c59900000000000000000000000000000000000000000000000000000000000000010000000000000000000000004585fe77225b41b697c938b018e2ac67ac5a20c00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000012c
```
### ~setSwapInfo( WETH => WBTC) [UniV3]~
```
0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2,
0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599,
[
  '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
  '0xb858183f000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000830df56616d58976a12d19d283b40e25beefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002bc02aaa39b223fe8d0a0e5c4f27ead9083c756cc20001f42260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000',
  100,
  132,
  0
]
```
### ~setSwapInfo( WBTC => WETH) [UniV3]~
```
0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599,
0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2,
[
  '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
  '0xb858183f000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000830df56616d58976a12d19d283b40e25beefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002b2260fac5e5542a773aa44fbcfedf7c193bc2c5990001f4c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000000000000000000000',
  100,
  132,
  0
]
```