### PR TITLE
Fix /apy/breakdown: merkl folding + lending APR

### DIFF
--- a/src/api/stats/common/aave/getAaveV3Apys.js
+++ b/src/api/stats/common/aave/getAaveV3Apys.js
@@ -3,7 +3,7 @@ const BigNumber = require('bignumber.js');
 import { fetchPrice } from '../../../../utils/fetchPrice';
 import { getMerklOpportunitiesByProtocol } from '../../../offchain-rewards/providers/merkl/proxyClient';
 
-const { getApyBreakdown } = require('../getApyBreakdown');
+const { getApyBreakdown } = require('../getApyBreakdownNew');
 const { default: IAaveV3Incentives } = require('../../../../abis/AaveV3Incentives');
 const { default: IAaveV3PoolDataProvider } = require('../../../../abis/AaveV3PoolDataProvider');
 const { fetchContract } = require('../../../rpc/client');
@@ -31,11 +31,12 @@ const getAaveV3ApyData = async (config, pools, chainId) => {
   });
 
   return getApyBreakdown(
-    pools.map(p => ({ ...p, address: p.name })),
-    Object.fromEntries(pools.map((p, i) => [p.name, lendingApys[i]])),
-    rewardApys,
-    0,
-    lsApys
+    pools.map((p, i) => ({
+      vaultId: p.name,
+      lending: lendingApys[i],
+      vault: rewardApys[i],
+      liquidStaking: lsApys[i],
+    }))
   );
 };
 

--- a/src/api/stats/common/aave/getAaveV3Apys.js
+++ b/src/api/stats/common/aave/getAaveV3Apys.js
@@ -90,9 +90,6 @@ const getPoolApy = async (config, pool, chainId) => {
     if (pool.lsAprFactor) lsAprFactor = pool.lsAprFactor;
     lsApy = (lsApy * lsAprFactor) / 100;
   }
-  if (pool.skimLending) {
-    lendingApy = lendingApy.times(0.905);
-  }
   // console.log(pool.name, apy, supplyBase.valueOf(), borrowBase.valueOf(), supplyNative.valueOf(), borrowNative.valueOf());
   return [rewardsApy, lendingApy, lsApy];
 };

--- a/src/api/stats/common/aave/getAaveV4Apys.ts
+++ b/src/api/stats/common/aave/getAaveV4Apys.ts
@@ -59,7 +59,7 @@ export const getAaveV4ApyData = async (chainId: number, pools: AaveV4Pool[]) => 
   return getApyBreakdown(
     pools.map((pool, i) => ({
       vaultId: pool.name,
-      trading: data[i].lendingApr,
+      lending: data[i].lendingApr,
       vault: data[i].merklApr,
     }))
   );

--- a/src/api/stats/common/balancer/getBalancerApys.ts
+++ b/src/api/stats/common/balancer/getBalancerApys.ts
@@ -66,10 +66,7 @@ export const getBalancerApys = async (params: BalancerParams): Promise<ApyBreakd
     tradingAprs.tradingAprMap as Record<string, BigNumber>,
     poolApys.farmAprs,
     liquidityProviderFee,
-    tradingAprs.lstAprs,
-    undefined,
-    undefined,
-    poolApys.merklAprs
+    tradingAprs.lstAprs
   );
 };
 
@@ -89,7 +86,6 @@ const getPoolApys = async (params: BalancerParams) => {
       : {};
 
   const farmAprs: BigNumber[] = [];
-  const merklAprs: number[] = [];
 
   const poolApyCalls = params.pools.map(pool => getPoolApy(pool, params));
   const poolApyResults = await Promise.all(poolApyCalls);
@@ -98,13 +94,12 @@ const getPoolApys = async (params: BalancerParams) => {
     const addressKey = pool.address?.toLowerCase?.();
     const merklApr = pool.merkl && addressKey ? merklAprByAddress[addressKey] ?? 0 : 0;
 
-    // Merkl is a distinct non-compoundable component in breakdowns.
-    // Keep farm/vault APR at 0 for merkl pools.
-    merklAprs[i] = merklApr;
-    farmAprs[i] = pool.merkl ? new BigNumber(0) : poolApyResults[i] ?? new BigNumber(0);
+    // fold merkl into vault APR (fee charged + autocompounded), not a standalone merklApr
+    const base = pool.merkl ? new BigNumber(0) : poolApyResults[i] ?? new BigNumber(0);
+    farmAprs[i] = base.plus(merklApr);
   });
 
-  return { farmAprs, merklAprs };
+  return { farmAprs };
 };
 
 const getPoolApy = async (pool: Pool, params: BalancerParams) => {

--- a/src/api/stats/common/curve/getCurveLendApys.js
+++ b/src/api/stats/common/curve/getCurveLendApys.js
@@ -1,0 +1,13 @@
+import { getCurveLendSupplyApys } from './getCurveLendSupplyApys';
+
+// Curve-lend vaults: supply APY -> lending (fee charged, not autocompounded);
+// gauge/convex rewards -> vault (autocompounded).
+export const getCurveLendApyRequests = async (chainId, lendPools, farmAprByName, providerFee) => {
+  const lendApys = await getCurveLendSupplyApys(chainId, lendPools);
+  return lendPools.map(pool => ({
+    vaultId: pool.name,
+    lending: lendApys[pool.name],
+    vault: farmAprByName[pool.name],
+    providerFee,
+  }));
+};

--- a/src/api/stats/common/euler/getEulerApys.ts
+++ b/src/api/stats/common/euler/getEulerApys.ts
@@ -27,7 +27,7 @@ const getEulerApyData = async (params: EulerApyParams) => {
   return getApyBreakdown(
     params.pools.map(p => ({
       vaultId: p.name,
-      trading: supplyApys[params.pools.indexOf(p)],
+      lending: supplyApys[params.pools.indexOf(p)],
       vault: merklApys[params.pools.indexOf(p)],
     }))
   );

--- a/src/api/stats/common/gearbox/getGearboxApys.js
+++ b/src/api/stats/common/gearbox/getGearboxApys.js
@@ -23,5 +23,5 @@ const getPoolsApys = async (chainId, pools) => {
   }
   const [supplyRates] = await Promise.all([Promise.all(supplyRateCalls)]);
 
-  return supplyRates.map(v => new BigNumber(v.toString()).div(1e27).times(0.905));
+  return supplyRates.map(v => new BigNumber(v.toString()).div(1e27));
 };

--- a/src/api/stats/common/gearbox/getGearboxApys.js
+++ b/src/api/stats/common/gearbox/getGearboxApys.js
@@ -5,15 +5,12 @@ import GearboxVault from '../../../../abis/GearboxVault';
 import { getMerklApys } from '../getMerklApys';
 
 export const getGearboxApys = async (chainId, pools) => {
-  const [supplyApys, merklApys] = await Promise.all([
-    getPoolsApys(chainId, pools),
-    getMerklApys(chainId, pools),
-  ]);
+  const [supplyApys, merklApys] = await Promise.all([getPoolsApys(chainId, pools), getMerklApys(chainId, pools)]);
 
   return getApyBreakdown(
     pools.map(p => ({
       vaultId: p.name,
-      trading: supplyApys[pools.indexOf(p)],
+      lending: supplyApys[pools.indexOf(p)],
       vault: merklApys[pools.indexOf(p)],
     }))
   );

--- a/src/api/stats/common/getApyBreakdownNew.ts
+++ b/src/api/stats/common/getApyBreakdownNew.ts
@@ -4,6 +4,7 @@ import { BASE_HPY } from '../../../constants';
 import { getTotalPerformanceFeeForVault } from '../../vaults/getVaultFees';
 import { getFarmWithTradingFeesApy } from '../../../utils/getFarmWithTradingFeesApy';
 import { toArray } from '../../../utils/array';
+import { getVaultById } from '../getMultichainVaults';
 
 // These component lists need to stay in sync with the app
 // Total APY = (((1 + Compounded APY) * (1 + Special APR)) - 1) + Non-Compoundable APR.
@@ -28,9 +29,32 @@ const nonCompoundableComponents = [
 /** special component */
 const specialComponents = ['trading'] as const;
 
+/** lending component - fee charged but not autocompounded */
+const lendingComponents = ['lending'] as const;
+
+// Platforms whose base supply yield is reported as lendingApr instead of tradingApr
+const LENDING_PLATFORM_IDS = new Set([
+  'curve-lend',
+  'aave',
+  'aave-v4',
+  'compound',
+  'moonwell',
+  'silo',
+  'mendi',
+  'lendle',
+  'yei',
+  'morpho',
+  'euler',
+  'imf',
+  'curvance',
+  'neverland',
+  'gearbox',
+]);
+
 type CompoundableComponent = (typeof compoundableComponents)[number];
 type NonCompoundableComponent = (typeof nonCompoundableComponents)[number];
 type SpecialComponent = (typeof specialComponents)[number];
+type LendingComponent = (typeof lendingComponents)[number];
 
 type ToAprComponents<T extends string> = {
   [key in T as `${key}Apr`]?: number | undefined;
@@ -38,7 +62,8 @@ type ToAprComponents<T extends string> = {
 
 type AprBreakdown = ToAprComponents<CompoundableComponent> &
   ToAprComponents<NonCompoundableComponent> &
-  ToAprComponents<SpecialComponent>;
+  ToAprComponents<SpecialComponent> &
+  ToAprComponents<LendingComponent>;
 
 export type ApyBreakdown = AprBreakdown & {
   /**
@@ -73,7 +98,8 @@ type ToInputComponents<T extends string> = {
 
 type BreakdownRequestComponents = ToInputComponents<CompoundableComponent> &
   ToInputComponents<NonCompoundableComponent> &
-  ToInputComponents<SpecialComponent>;
+  ToInputComponents<SpecialComponent> &
+  ToInputComponents<LendingComponent>;
 
 /**
  * Total APY = (((1 + Compounded APY) * (1 + Special APR)) - 1) + Non-Compoundable APR.
@@ -102,6 +128,9 @@ export function getApyBreakdownOnly(request: ApyBreakdownRequest): ApyBreakdown 
     totalApy: 0,
   };
 
+  const platformId = getVaultById(request.vaultId)?.platformId;
+  const isLendingVault = !!platformId && LENDING_PLATFORM_IDS.has(platformId);
+
   let totalCompoundable = 0;
   for (const component of compoundableComponents) {
     const apr = toNumber(request[component]);
@@ -121,19 +150,38 @@ export function getApyBreakdownOnly(request: ApyBreakdownRequest): ApyBreakdown 
     }
   }
 
+  let totalLending = 0;
+
   let totalSpecial = 0;
   for (const component of specialComponents) {
     const apr = toNumber(request[component]);
     if (apr !== undefined) {
-      breakdown[`${component}Apr`] = apr;
-      totalSpecial += apr;
+      // lending platforms pass their supply yield via `trading`
+      if (component === 'trading' && isLendingVault) {
+        const aprAfterFee = apr * shareAfterBeefyPerformanceFee;
+        breakdown.lendingApr = aprAfterFee;
+        totalLending += aprAfterFee;
+      } else {
+        breakdown[`${component}Apr`] = apr;
+        totalSpecial += apr;
+      }
+    }
+  }
+
+  for (const component of lendingComponents) {
+    const apr = toNumber(request[component]);
+    if (apr !== undefined) {
+      const aprAfterFee = apr * shareAfterBeefyPerformanceFee;
+      breakdown[`${component}Apr`] = aprAfterFee;
+      totalLending += aprAfterFee;
     }
   }
 
   // @dev shareAfterBeefyPerformanceFee = 1 as fee is already removed from all components
   breakdown.totalApy =
     getFarmWithTradingFeesApy(totalCompoundable, totalSpecial, compoundingsPerYear, 1, 1) +
-    totalNonCompoundable;
+    totalNonCompoundable +
+    totalLending;
 
   return breakdown;
 }

--- a/src/api/stats/common/getApyBreakdownNew.ts
+++ b/src/api/stats/common/getApyBreakdownNew.ts
@@ -4,7 +4,6 @@ import { BASE_HPY } from '../../../constants';
 import { getTotalPerformanceFeeForVault } from '../../vaults/getVaultFees';
 import { getFarmWithTradingFeesApy } from '../../../utils/getFarmWithTradingFeesApy';
 import { toArray } from '../../../utils/array';
-import { getVaultById } from '../getMultichainVaults';
 
 // These component lists need to stay in sync with the app
 // Total APY = (((1 + Compounded APY) * (1 + Special APR)) - 1) + Non-Compoundable APR.
@@ -31,25 +30,6 @@ const specialComponents = ['trading'] as const;
 
 /** lending component - fee charged but not autocompounded */
 const lendingComponents = ['lending'] as const;
-
-// Platforms whose base supply yield is reported as lendingApr instead of tradingApr
-const LENDING_PLATFORM_IDS = new Set([
-  'curve-lend',
-  'aave',
-  'aave-v4',
-  'compound',
-  'moonwell',
-  'silo',
-  'mendi',
-  'lendle',
-  'yei',
-  'morpho',
-  'euler',
-  'imf',
-  'curvance',
-  'neverland',
-  'gearbox',
-]);
 
 type CompoundableComponent = (typeof compoundableComponents)[number];
 type NonCompoundableComponent = (typeof nonCompoundableComponents)[number];
@@ -128,9 +108,6 @@ export function getApyBreakdownOnly(request: ApyBreakdownRequest): ApyBreakdown 
     totalApy: 0,
   };
 
-  const platformId = getVaultById(request.vaultId)?.platformId;
-  const isLendingVault = !!platformId && LENDING_PLATFORM_IDS.has(platformId);
-
   let totalCompoundable = 0;
   for (const component of compoundableComponents) {
     const apr = toNumber(request[component]);
@@ -150,24 +127,17 @@ export function getApyBreakdownOnly(request: ApyBreakdownRequest): ApyBreakdown 
     }
   }
 
-  let totalLending = 0;
-
   let totalSpecial = 0;
   for (const component of specialComponents) {
     const apr = toNumber(request[component]);
     if (apr !== undefined) {
-      // lending platforms pass their supply yield via `trading`
-      if (component === 'trading' && isLendingVault) {
-        const aprAfterFee = apr * shareAfterBeefyPerformanceFee;
-        breakdown.lendingApr = aprAfterFee;
-        totalLending += aprAfterFee;
-      } else {
-        breakdown[`${component}Apr`] = apr;
-        totalSpecial += apr;
-      }
+      breakdown[`${component}Apr`] = apr;
+      totalSpecial += apr;
     }
   }
 
+  // lending yield: fee charged but not autocompounded, so added linearly net of fee
+  let totalLending = 0;
   for (const component of lendingComponents) {
     const apr = toNumber(request[component]);
     if (apr !== undefined) {

--- a/src/api/stats/common/getCompoundV3Apys.ts
+++ b/src/api/stats/common/getCompoundV3Apys.ts
@@ -5,7 +5,7 @@ import { fetchPrice } from '../../../utils/fetchPrice';
 import cv3Token from '../../../abis/cv3Token';
 import { Abi } from 'viem';
 import { fetchContract, fetchNoMulticallContract } from '../../rpc/client';
-import getApyBreakdown from './getApyBreakdown';
+import { getApyBreakdown } from './getApyBreakdownNew';
 
 const SECONDS_PER_YEAR = 31536000;
 
@@ -15,15 +15,15 @@ const getCompoundV3ApyData = async (params: CompoundV3ApyParams) => {
   const { supplyApys, supplyCompApys } = await getPoolsApys(params, poolsData);
 
   if (params.log) {
-    params.pools.forEach((pool, i) =>
-      console.log(pool.name, supplyApys[i].valueOf(), supplyCompApys[i].valueOf())
-    );
+    params.pools.forEach((pool, i) => console.log(pool.name, supplyApys[i].valueOf(), supplyCompApys[i].valueOf()));
   }
 
   return getApyBreakdown(
-    params.pools.map(p => ({ ...p, address: p.name })),
-    Object.fromEntries(params.pools.map((p, i) => [p.name, supplyApys[i]])),
-    supplyCompApys
+    params.pools.map((p, i) => ({
+      vaultId: p.name,
+      lending: supplyApys[i],
+      vault: supplyCompApys[i],
+    }))
   );
 };
 

--- a/src/api/stats/common/morpho/getMorphoApys.js
+++ b/src/api/stats/common/morpho/getMorphoApys.js
@@ -2,20 +2,18 @@ import BigNumber from 'bignumber.js';
 import { getApyBreakdown } from '../getApyBreakdownNew';
 
 // Helper function to calculate APY breakdown
-const calculateApyBreakdown = (apy, isV2, isSkim) => {
+const calculateApyBreakdown = (apy, isV2) => {
   if (isV2) {
     const lending = new BigNumber(apy?.avgNetApyExcludingRewards || 0);
     const assetYield = new BigNumber(apy?.asset?.yield?.apr || 0);
-    let trading = lending.plus(assetYield);
+    const trading = lending.plus(assetYield);
     const vault = new BigNumber(apy?.avgNetApy || 0).minus(lending);
-    if (isSkim) trading = lending.times(0.905).plus(assetYield);
     return { vault, trading };
   } else {
     const lending = new BigNumber(apy?.state?.avgNetApyExcludingRewards || 0);
     const assetYield = new BigNumber(apy?.asset?.yield?.apr || 0);
-    let trading = lending.plus(assetYield);
+    const trading = lending.plus(assetYield);
     const vault = new BigNumber(apy?.state?.avgNetApy || 0).minus(lending);
-    if (isSkim) trading = lending.times(0.905).plus(assetYield);
     return { vault, trading };
   }
 };
@@ -102,7 +100,7 @@ export const getMorphoApys = async (chainId, pools) => {
   return getApyBreakdown(
     pools.map(pool => {
       const apy = pool.v2 ? apyMapV2.get(pool.address) : apyMapV1.get(pool.address);
-      const { vault, trading } = calculateApyBreakdown(apy, pool.v2, pool.skim);
+      const { vault, trading } = calculateApyBreakdown(apy, pool.v2);
 
       return {
         vaultId: pool.name,

--- a/src/api/stats/common/morpho/getMorphoApys.js
+++ b/src/api/stats/common/morpho/getMorphoApys.js
@@ -107,7 +107,7 @@ export const getMorphoApys = async (chainId, pools) => {
       return {
         vaultId: pool.name,
         vault,
-        trading,
+        lending: trading,
       };
     })
   );

--- a/src/api/stats/common/silo/getSiloApys.js
+++ b/src/api/stats/common/silo/getSiloApys.js
@@ -50,7 +50,7 @@ export const getSiloApys = async (chainId, pools) => {
         return {
           vaultId: pool.name,
           vault: new BigNumber(0),
-          trading: new BigNumber(0),
+          lending: new BigNumber(0),
         };
       }
 
@@ -68,20 +68,20 @@ export const getSiloApys = async (chainId, pools) => {
         return {
           vaultId: pool.name,
           vault: protectedRewardsApr.isNegative() ? new BigNumber(0) : protectedRewardsApr,
-          trading: underlyingApy.isNegative() ? new BigNumber(0) : underlyingApy,
+          lending: underlyingApy.isNegative() ? new BigNumber(0) : underlyingApy,
         };
       } else {
         // Handle vault API response structure (existing logic)
         const totalApr = new BigNumber(data.supplyApr || 0).div(1e18);
         const baseApr = new BigNumber(data.supplyBaseApr || 0).div(1e18);
 
-        const trading = baseApr;
+        const lending = baseApr;
         const vault = totalApr.minus(baseApr);
 
         return {
           vaultId: pool.name,
           vault: vault.isNegative() ? new BigNumber(0) : vault,
-          trading: trading.isNegative() ? new BigNumber(0) : trading,
+          lending: lending.isNegative() ? new BigNumber(0) : lending,
         };
       }
     })

--- a/src/api/stats/ethereum/getConvexApys.js
+++ b/src/api/stats/ethereum/getConvexApys.js
@@ -1,12 +1,12 @@
 import { ETH_CHAIN_ID } from '../../../constants';
 import { getCurveSubgraphApys } from '../common/curve/getCurveApyData';
-import getApyBreakdown from '../common/getApyBreakdown';
+import { getApyBreakdown } from '../common/getApyBreakdownNew';
 import BigNumber from 'bignumber.js';
 import { fetchPrice } from '../../../utils/fetchPrice';
 import IRewardPool from '../../../abis/IRewardPool';
 import { fetchContract } from '../../rpc/client';
 import ERC20Abi from '../../../abis/ERC20Abi';
-import { getCurveLendSupplyApys } from '../common/curve/getCurveLendSupplyApys';
+import { getCurveLendApyRequests } from '../common/curve/getCurveLendApys';
 
 const lpPools = require('../../../data/ethereum/convexPools.json').filter(p => p.rewardPool);
 const lendPools = require('../../../data/ethereum/curveLendPools.json').filter(p => p.rewardPool);
@@ -16,15 +16,27 @@ const secondsPerYear = 31536000;
 const cvxAddress = '0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B';
 
 const pools = [...lpPools, ...lendPools];
+const lendPoolNames = new Set(lendPools.map(p => p.name));
 
 export const getConvexApys = async () => {
-  const [baseApys, lendApys, farmApys] = await Promise.all([
-    getCurveSubgraphApys(lpPools, subgraphUrl),
-    getCurveLendSupplyApys(ETH_CHAIN_ID, lendPools),
-    getPoolApys(pools),
-  ]);
-  const poolsMap = pools.map(p => ({ name: p.name, address: p.name }));
-  return getApyBreakdown(poolsMap, { ...baseApys, ...lendApys }, farmApys, tradingFees);
+  const [baseApys, farmApys] = await Promise.all([getCurveSubgraphApys(lpPools, subgraphUrl), getPoolApys(pools)]);
+  const farmAprByName = Object.fromEntries(pools.map((p, i) => [p.name, farmApys[i]]));
+
+  const lpRequests = pools
+    .filter(p => !lendPoolNames.has(p.name))
+    .map(p => ({
+      vaultId: p.name,
+      trading: baseApys[p.name],
+      vault: farmAprByName[p.name],
+      providerFee: tradingFees,
+    }));
+  const lendRequests = await getCurveLendApyRequests(
+    ETH_CHAIN_ID,
+    pools.filter(p => lendPoolNames.has(p.name)),
+    farmAprByName,
+    tradingFees
+  );
+  return getApyBreakdown([...lpRequests, ...lendRequests]);
 };
 
 const getPoolApys = async pools => {

--- a/src/api/stats/ethereum/getCurveApys.js
+++ b/src/api/stats/ethereum/getCurveApys.js
@@ -1,7 +1,7 @@
 import { ETH_CHAIN_ID } from '../../../constants';
-import getApyBreakdown from '../common/getApyBreakdown';
+import { getApyBreakdown } from '../common/getApyBreakdownNew';
 import { getCurveVolumeApys } from '../common/curve/getCurveApyData';
-import { getCurveLendSupplyApys } from '../common/curve/getCurveLendSupplyApys';
+import { getCurveLendApyRequests } from '../common/curve/getCurveLendApys';
 import BigNumber from 'bignumber.js';
 import { fetchPrice } from '../../../utils/fetchPrice';
 import ICurveGauge from '../../../abis/ICurveGauge';
@@ -18,15 +18,27 @@ const volumeUrl = 'https://api.curve.finance/api/getVolumes/ethereum';
 const lpPools = require('../../../data/ethereum/convexPools.json');
 const lendPools = require('../../../data/ethereum/curveLendPools.json');
 const pools = [...lpPools, ...lendPools].filter(p => p.gauge && !p.rewardPool);
+const lendPoolNames = new Set(lendPools.map(p => p.name));
 
 export const getCurveApys = async () => {
-  const [baseApys, lendApys, farmApys] = await Promise.all([
-    getCurveVolumeApys(lpPools, volumeUrl),
-    getCurveLendSupplyApys(ETH_CHAIN_ID, lendPools),
-    getPoolApys(pools),
-  ]);
-  const poolsMap = pools.map(p => ({ name: p.name, address: p.name }));
-  return getApyBreakdown(poolsMap, { ...baseApys, ...lendApys }, farmApys, tradingFees);
+  const [baseApys, farmApys] = await Promise.all([getCurveVolumeApys(lpPools, volumeUrl), getPoolApys(pools)]);
+  const farmAprByName = Object.fromEntries(pools.map((p, i) => [p.name, farmApys[i]]));
+
+  const lpRequests = pools
+    .filter(p => !lendPoolNames.has(p.name))
+    .map(p => ({
+      vaultId: p.name,
+      trading: baseApys[p.name],
+      vault: farmAprByName[p.name],
+      providerFee: tradingFees,
+    }));
+  const lendRequests = await getCurveLendApyRequests(
+    ETH_CHAIN_ID,
+    pools.filter(p => lendPoolNames.has(p.name)),
+    farmAprByName,
+    tradingFees
+  );
+  return getApyBreakdown([...lpRequests, ...lendRequests]);
 };
 
 const getPoolApys = async pools => {

--- a/src/api/stats/monad/getCurvanceApys.ts
+++ b/src/api/stats/monad/getCurvanceApys.ts
@@ -10,16 +10,14 @@ const pools: CurvancePool[] = require('../../../data/monad/curvancePools.json');
 const SECONDS_PER_YEAR = 31536000;
 
 export const getCurvanceApys = async () => {
-  const [supplyApys, merklApys] = await Promise.all([
-    getPoolsApys(pools),
-    getMerklApys(MONAD_CHAIN_ID, pools),
-  ]);
+  const [supplyApys, merklApys] = await Promise.all([getPoolsApys(pools), getMerklApys(MONAD_CHAIN_ID, pools)]);
 
   return getApyBreakdown(
     pools.map(p => ({
       vaultId: p.name,
-      vault: supplyApys[pools.indexOf(p)].plus(merklApys[pools.indexOf(p)]),
-      trading: p.lstApr ?? undefined,
+      lending: supplyApys[pools.indexOf(p)],
+      vault: merklApys[pools.indexOf(p)],
+      liquidStaking: p.lstApr ?? undefined,
     }))
   );
 };
@@ -47,9 +45,7 @@ const getPoolsApys = async (pools: CurvancePool[]): Promise<BigNumber[]> => {
   for (let i = 0; i < pools.length; i++) {
     const pool = pools[i];
     const IRMContract = fetchContract(pool.irm, ICurvanceIRM, MONAD_CHAIN_ID) as any;
-    supplyRates.push(
-      IRMContract.read.supplyRate([res[0][i].toString(), res[1][i].toString(), res[2][i].toString()])
-    );
+    supplyRates.push(IRMContract.read.supplyRate([res[0][i].toString(), res[1][i].toString(), res[2][i].toString()]));
   }
 
   const apys = await Promise.all(supplyRates);

--- a/src/api/stats/monad/getNeverlandApys.ts
+++ b/src/api/stats/monad/getNeverlandApys.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import getApyBreakdown, { ApyBreakdownResult } from '../common/getApyBreakdown';
+import { getApyBreakdown, ApyBreakdownResult } from '../common/getApyBreakdownNew';
 import { fetchPrice } from '../../../utils/fetchPrice';
 import { MONAD_CHAIN_ID } from '../../../constants';
 import { fetchContract } from '../../rpc/client';
@@ -21,20 +21,26 @@ const burn = 0.5;
 export const getNeverlandApys = async (): Promise<ApyBreakdownResult> => {
   const farmAprs: BigNumber[] = [];
 
-  const [{ supplyAprs, suppliesInUsd }, rewardInUsdPerSecond, liquidStakingAprs, merklApys] =
-    await Promise.all([
-      getPoolData(),
-      getIncentiveControllerData(),
-      getLiquidStakingData(),
-      getMerklApys(MONAD_CHAIN_ID, pools),
-    ]);
+  const [{ supplyAprs, suppliesInUsd }, rewardInUsdPerSecond, liquidStakingAprs, merklApys] = await Promise.all([
+    getPoolData(),
+    getIncentiveControllerData(),
+    getLiquidStakingData(),
+    getMerklApys(MONAD_CHAIN_ID, pools),
+  ]);
 
   for (let i = 0; i < pools.length; ++i) {
     const farmApr = rewardInUsdPerSecond[i].dividedBy(suppliesInUsd[i]).times(secondsPerYear);
     farmAprs.push(farmApr.plus(merklApys[i]));
   }
 
-  return getApyBreakdown(pools, supplyAprs, farmAprs, 0, liquidStakingAprs);
+  return getApyBreakdown(
+    pools.map((pool, i) => ({
+      vaultId: pool.name,
+      lending: supplyAprs[pool.address.toLowerCase()],
+      vault: farmAprs[i],
+      liquidStaking: liquidStakingAprs[i],
+    }))
+  );
 };
 
 const getPoolData = async () => {
@@ -46,9 +52,7 @@ const getPoolData = async () => {
     const poolData = await dataProvider.read.getReserveData([pool.address]);
     const tokenPrice = await fetchPrice({ oracle: 'tokens', id: pool.oracleId });
 
-    supplyAprs[pool.address.toLowerCase()] = new BigNumber(poolData[5].toString())
-      .dividedBy(RAY_DECIMALS)
-      .times(0.905); // skim lending
+    supplyAprs[pool.address.toLowerCase()] = new BigNumber(poolData[5].toString()).dividedBy(RAY_DECIMALS).times(0.905); // skim lending
     suppliesInUsd.push(
       new BigNumber(poolData[0].toString())
         .plus(new BigNumber(poolData[1].toString()))

--- a/src/api/stats/monad/getNeverlandApys.ts
+++ b/src/api/stats/monad/getNeverlandApys.ts
@@ -2,15 +2,16 @@ import BigNumber from 'bignumber.js';
 import { getApyBreakdown, ApyBreakdownResult } from '../common/getApyBreakdownNew';
 import { fetchPrice } from '../../../utils/fetchPrice';
 import { MONAD_CHAIN_ID } from '../../../constants';
-import { fetchContract } from '../../rpc/client';
+import { fetchContract, getMulticallClientForChain } from '../../rpc/client';
 import { getMerklApys } from '../common/curve/getCurveApysCommon';
 import jp from 'jsonpath';
-import IAaveProtocolDataProviderAbi from '../../../abis/matic/AaveProtocolDataProvider';
+import IAaveV3PoolDataProvider from '../../../abis/AaveV3PoolDataProvider';
 import NeverlandIncentiveController from '../../../abis/monad/NeverlandIncentiveController';
+import pools from '../../../data/monad/neverlandPools.json';
+import type { Address } from 'viem';
 
 const aaveProtocolDataProvider = '0xfd0b6b6F736376F7B99ee989c749007c7757fDba';
 const neverlandIncentiveController = '0x57ea245cCbFAb074baBb9d01d1F0c60525E52cec';
-const pools = require('../../../data/monad/neverlandPools.json');
 const rewardId = 'DUST';
 const rewardAddress = '0xAD96C3dffCD6374294e2573A7fBBA96097CC8d7c';
 const rewardDecimals = '1e18';
@@ -47,20 +48,21 @@ const getPoolData = async () => {
   const supplyAprs: Record<string, BigNumber> = {};
   const suppliesInUsd: BigNumber[] = [];
 
-  const dataProvider = fetchContract(aaveProtocolDataProvider, IAaveProtocolDataProviderAbi, MONAD_CHAIN_ID);
-  pools.forEach(async pool => {
-    const poolData = await dataProvider.read.getReserveData([pool.address]);
-    const tokenPrice = await fetchPrice({ oracle: 'tokens', id: pool.oracleId });
+  const dataProvider = fetchContract(aaveProtocolDataProvider, IAaveV3PoolDataProvider, MONAD_CHAIN_ID);
+  await Promise.allSettled(
+    pools.map(async (pool, i) => {
+      const [poolData, tokenPrice] = await Promise.all([
+        dataProvider.read.getReserveData([pool.address as Address]),
+        fetchPrice({ oracle: 'tokens', id: pool.oracleId }),
+      ]);
 
-    supplyAprs[pool.address.toLowerCase()] = new BigNumber(poolData[5].toString()).dividedBy(RAY_DECIMALS).times(0.905); // skim lending
-    suppliesInUsd.push(
-      new BigNumber(poolData[0].toString())
-        .plus(new BigNumber(poolData[1].toString()))
-        .plus(new BigNumber(poolData[2].toString()))
-        .dividedBy(pool.decimals)
-        .times(tokenPrice)
-    );
-  });
+      // 5=liquidityRate
+      supplyAprs[pool.address.toLowerCase()] = new BigNumber(poolData[5].toString()).dividedBy(RAY_DECIMALS);
+
+      // 2=totalAToken
+      suppliesInUsd[i] = new BigNumber(poolData[2].toString()).dividedBy(pool.decimals).times(tokenPrice);
+    })
+  );
 
   return { supplyAprs, suppliesInUsd };
 };
@@ -71,47 +73,62 @@ const getIncentiveControllerData = async (): Promise<BigNumber[]> => {
     NeverlandIncentiveController,
     MONAD_CHAIN_ID
   );
-  const poolInfoCalls = (pools as any[]).map(pool => {
-    return incentivesControllerContract.read.getRewardsData([pool.aToken, rewardAddress]);
+  const poolInfoCalls = pools.map(pool => {
+    return incentivesControllerContract.read.getRewardsData([pool.aToken as Address, rewardAddress]);
   });
   const poolInfos = await Promise.all(poolInfoCalls);
   const rewardPrice = await fetchPrice({ oracle: 'tokens', id: rewardId });
-  const rewardInUsdPerSecond: BigNumber[] = poolInfos.map(poolInfo =>
-    new BigNumber(poolInfo[1].toString()).dividedBy(rewardDecimals).times(rewardPrice).times(burn)
-  );
+  const nowInSeconds = Date.now() / 1000;
+  const rewardInUsdPerSecond: BigNumber[] = poolInfos.map(poolInfo => {
+    // 3=distributionEnd
+    const distributionEnd = new BigNumber(poolInfo[3].toString());
+    if (distributionEnd.lt(nowInSeconds)) {
+      return new BigNumber(0);
+    }
+
+    // 1=emissionPerSecond
+    return new BigNumber(poolInfo[1].toString()).dividedBy(rewardDecimals).times(rewardPrice).times(burn);
+  });
 
   return rewardInUsdPerSecond;
 };
 
-const getLiquidStakingData = async () => {
-  let liquidStakingAprs: number[] = [];
+const getLiquidStakingData = async (): Promise<number[]> => {
+  // Fetch once
+  const uniqueUrls = [...new Set(pools.filter(p => !!p.lsUrl).map(p => p.lsUrl!))];
+  const responseByUrl = new Map<string, any>();
 
-  for (let i = 0; i < pools.length; i++) {
-    if (pools[i].lsUrl) {
-      let lsAprFactor: number = 1;
-      if (pools[i].lsAprFactor) lsAprFactor = pools[i].lsAprFactor!;
-
-      let lsApr: number = 0;
+  await Promise.all(
+    uniqueUrls.map(async url => {
       try {
-        const url = pools[i].lsUrl!;
-        const lsResponse: any = await fetch(url).then(res => res.json());
+        responseByUrl.set(url, await fetch(url).then(res => res.json()));
+      } catch {
+        responseByUrl.set(url, null);
+        console.error(`Failed to fetch liquid staking APR from ${url}`);
+      }
+    })
+  );
 
-        lsApr = jp.query(lsResponse, pools[i].dataPath!)[0];
+  // Map by pool so the result stays index-aligned with `pools` even when a fetch/parse fails.
+  return pools.map(pool => {
+    if (pool.lsUrl) {
+      const response = responseByUrl.get(pool.lsUrl);
+      if (response == null) return 0; // fetch failed
+      try {
+        const lsAprFactor: number = pool.lsAprFactor || 1;
+        let lsApr = jp.query(response, pool.dataPath!)[0];
         if (String(lsApr).includes('%')) {
           lsApr = Number(String(lsApr).replace('%', ''));
         }
-        lsApr = (lsApr * lsAprFactor) / 100;
-        liquidStakingAprs.push(lsApr);
+        return (Number(lsApr) * lsAprFactor) / 100;
       } catch {
-        console.error(`Failed to fetch ${pools[i].name} liquid staking APR from ${pools[i].lsUrl}`);
+        console.error(`Failed to parse ${pool.name} liquid staking APR from ${pool.lsUrl}`);
+        return 0;
       }
-    } else if (pools[i].lstApr) {
-      liquidStakingAprs.push(pools[i].lstApr);
-    } else {
-      liquidStakingAprs.push(0);
     }
-  }
-  return liquidStakingAprs;
+    if (pool.lstApr) return pool.lstApr;
+    return 0;
+  });
 };
 
 export default getNeverlandApys;


### PR DESCRIPTION
- Fold merkl into vaultApr for autocompounding vaults (Balancer was the only one still emitting a standalone merklApr); CLM pools/reward-pools keep merklApr as-is.
- Lending vaults (15 platforms, matched by platformId) now report lendingApr instead of tradingApr — performance fee applied, not autocompounded.

examples: 
### Lending apr: 
```json
{
"aavev3-base-cbeth": {
 "compoundingsPerYear": 2190,
 "beefyPerformanceFee": 0.095,
 "lpFee": 0,
 "totalApy": 0.024503924696621056,
 "vaultApr": 0,
 "liquidStakingApr": 0.0245,
 "lendingApr": 0.0000039246966210545474
},
```
### Merkl fix 
Before 
```json
"balancerv3-monad-usdt0-ausd-usdc": {
"compoundingsPerYear": 2190,
"beefyPerformanceFee": 0.095,
"lpFee": 0.0025,
"totalApy": 0.07702380441734455,
"vaultApr": 0,
"liquidStakingApr": 0.0165609199653053,
"merklApr": 0.05987219653775562,
"tradingApr": 0.0005906879142835249
},

```

After
```json
"balancerv3-monad-usdt0-ausd-usdc": {
"compoundingsPerYear": 2190,
"beefyPerformanceFee": 0.095,
"lpFee": 0.0025,
"totalApy": 0.07272067479498517,
"vaultApr": 0.05395479314316536,
"liquidStakingApr": 0.016661054775983848,
"tradingApr": 0.0005906879142835249
},


```