### PR TITLE
Add PLUS Mainnet configuration

### DIFF
--- a/packages/address-book/src/address-book/plus/index.ts
+++ b/packages/address-book/src/address-book/plus/index.ts
@@ -1,0 +1,13 @@
+export const plus = {
+  name: 'PLUS Mainnet',
+  chainId: 88088,
+  rpc: ['https://plusmain.net/api/rpc'],
+  explorerUrl: 'https://plusmain.net/scan',
+  explorerTokenUrl: 'https://plusmain.net/scan/token/{address}',
+  nativeCurrency: {
+    name: 'PLUS',
+    symbol: 'PLUS',
+    decimals: 18,
+    address: '0x0000000000000000000000000000000000000000',
+  },
+} as const;


### PR DESCRIPTION
This PR adds PLUS Mainnet (Chain ID: 88088) support to Beefy Finance API.

RPC: https://plusmain.net/api/rpc
Explorer: https://plusmain.net/scan
Native Symbol: PLUS
Zero-Gas Layer-1 Protocol