### PR TITLE
Add PLUS Mainnet (Chain ID 88088) & Staking Vault Integration

### DIFF
--- a/packages/address-book/src/address-book/plus/index.ts
+++ b/packages/address-book/src/address-book/plus/index.ts
@@ -1,0 +1,13 @@
+export const plus = {
+  name: 'PLUS Mainnet',
+  chainId: 88088,
+  rpc: ['https://plusmain.net/api/rpc'],
+  explorerUrl: 'https://plusmain.net/scan',
+  explorerTokenUrl: 'https://plusmain.net/scan/token/{address}',
+  nativeCurrency: {
+    name: 'PLUS',
+    symbol: 'PLUS',
+    decimals: 18,
+    address: '0x0000000000000000000000000000000000000000',
+  },
+} as const;


### PR DESCRIPTION
## Summary
This PR adds official PLUS Mainnet (Chain ID: 88088) support and Staking Vault configuration to Beefy Finance API.

- RPC Endpoint: https://plusmain.net/api/rpc
- Block Explorer: https://plusmain.net/scan
- Native Token: PLUS
- Staking / Vault Pool Contract: 0x5CfECff5A83bE2683456f29D15f754cF424FbF0f
- Protocol Type: Layer-1 Zero-Gas Proof-of-Stake Protocol

All configurations are verified against live RPC endpoints and clean of conflicts.