### PR TITLE
Update Mellow USDC-cbBTC Oracle ID

### DIFF
--- a/src/data/base/mellowAeroPools.json
+++ b/src/data/base/mellowAeroPools.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "mellow-aero-usdc-cbbtc",
+    "name": "mellow-aero-usdc-cbbtc-v2",
     "address": "0x0Df5f2662e4a8C801c04D83Df717476509816250",
     "tokens": ["USDC", "cbBTC"]
   },


### PR DESCRIPTION
[V2 PR](https://github.com/beefyfinance/beefy-v2/pull/3370)

<img width="696" height="360" alt="Screenshot 2026-09-02 at 15 10 45" src="https://github.com/user-attachments/assets/d91babf3-93bf-4e59-8220-f6143b88ede6" />

**Problem:** This product reuses an old oracleId for a previous version of the same pairing for Mellow Aerodrome. Users flagged concerns with the historic charts, particularly the gap from 18 May 2026 to present where figures were frozen after the first product was removed from the API. The new product is actually a total redeploy, and so the presented history is also not representative.

**Solution:** Update the oracleId to include a `-v2` suffix, thereby disassociate the new product from the old history retained by the API. Will lose performance data between second product's launch and V2 PR's deploy, but no history is preferable to incorrect history.